### PR TITLE
Add externals to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 SavedInstances_Main.lua
+libs/


### PR DESCRIPTION
This allows for local testing after adding the libraries without having git consider them for staging.