### PR TITLE
Fix weekly reward tracking for keystone dungeons

### DIFF
--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -2871,7 +2871,10 @@ function core:updateRealmMap()
   end
 end
 
-function core:RefreshMythicKeyInfo()
+function core:RefreshMythicKeyInfo(event)
+
+  if (event ~= "CHALLENGE_MODE_MAPS_UPDATE") then C_ChallengeMode.RequestRewards() end -- This event is fired after the rewards data was requested, causing yet another refresh if not checked for
+
   local t = vars.db.Toons[thisToon]
   local _
   t.MythicKey = {}
@@ -2928,7 +2931,6 @@ function core:RefreshMythicKeyInfo()
   end
   local MythicMaps = { }
   C_ChallengeMode.RequestMapInfo()
-  C_ChallengeMode.RequestRewards()
   MythicMaps = C_ChallengeMode.GetMapTable()
   local bestlevel = 0
   for i = 1, #MythicMaps do

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -2928,6 +2928,7 @@ function core:RefreshMythicKeyInfo()
   end
   local MythicMaps = { }
   C_ChallengeMode.RequestMapInfo()
+  C_ChallengeMode.RequestRewards()
   MythicMaps = C_ChallengeMode.GetMapTable()
   local bestlevel = 0
   for i = 1, #MythicMaps do


### PR DESCRIPTION
<del>Labelled WIP so it doesn't get merged before I have some feedback.</del> I can squash this after somebody else has taken a look at it, since I'm not too happy with the approach, yet I didn't want to change too much just for this small fix.

With the previous change (a4311dc436d3d51359b3e88b5dc0d9b354b09623), there came an unintended side effect of C_ChallengeMode.RequestRewards() triggering the very same event SavedInstances used to update the MythicKeystone info, causing a perpetual loop and noticeable performance degradation for many users (though not for myself - don't ask me why).

The condition I've added this time around should prevent that from occurring, even if it doesn't address the inherent performance issues already present in the update routines.