### PR TITLE
Updating fetching of map ID. Map floors no longer exist.

### DIFF
--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -1975,15 +1975,7 @@ function addon:QuestIsDarkmoonMonthly()
 end
 
 function addon:GetCurrentMapAreaID()
-  local oldmap = GetCurrentMapAreaID()
-  local oldlvl = GetCurrentMapDungeonLevel()
-  SetMapToCurrentZone()
-  local map = GetCurrentMapAreaID()
-  SetMapByID(oldmap)
-  if oldlvl and oldlvl > 0 then
-    SetDungeonMapLevel(oldlvl)
-  end
-  return map
+  return C_Map.GetBestMapForUnit("player")
 end
 
 local function SI_GetQuestReward()


### PR DESCRIPTION
As HereBeDragons addon author wrote on wowinterface forums: "MapAreaId/Floor are gone, replaced by UiMapId (every map you see has its own unique id, no longer dealing with floors etc)".