### PR TITLE
LFR, World Bosses and Trade Skill

### DIFF
--- a/SavedInstances/LFR.lua
+++ b/SavedInstances/LFR.lua
@@ -69,6 +69,16 @@ addon.LFRInstances = {
   [1731] = { total=3, base=1, parent=1889, altid=nil, remap={ 1, 2, 3 } }, -- Uldir: Halls of Containment
   [1732] = { total=3, base=4, parent=1889, altid=nil, remap={ 1, 2, 3 } }, -- Uldir: Crimson Descent
   [1733] = { total=2, base=7, parent=1889, altid=nil, remap={ 1, 2 } },  -- Uldir: Heart of Corruption
+
+  [1945] = { total=3, base=1, parent=1942, altid=nil, remap={ 1, 2, 3 } }, -- Battle of Dazar'alor: Alliance Wing 1
+  [1946] = { total=3, base=4, parent=1942, altid=nil, remap={ 1, 2, 3 } }, -- Battle of Dazar'alor: Alliance Wing 2
+  [1947] = { total=3, base=7, parent=1942, altid=nil, remap={ 1, 2, 3 } }, -- Battle of Dazar'alor: Alliance Wing 3
+
+  [1948] = { total=3, base=1, parent=1942, altid=nil, remap={ 1, 2, 3 } }, -- Battle of Dazar'alor: Horde Wing 1
+  [1949] = { total=3, base=4, parent=1942, altid=nil, remap={ 1, 2, 3 } }, -- Battle of Dazar'alor: Horde Wing 2
+  [1950] = { total=3, base=7, parent=1942, altid=nil, remap={ 1, 2, 3 } }, -- Battle of Dazar'alor: Horde Wing 3
+
+  [1951] = { total=2, base=1, parent=1952, altid=nil, remap={ 1, 2 } }, -- Crucible of Storms
 }
 
 local tmp = {}

--- a/SavedInstances/MythicPlus.lua
+++ b/SavedInstances/MythicPlus.lua
@@ -89,18 +89,6 @@ function MythicPlusModule:RefreshMythicKeyInfo(event)
       end
     end
   end
-  local MythicMaps = { }
-  C_MythicPlus.RequestMapInfo()
-  MythicMaps = C_ChallengeMode.GetMapTable()
-  local bestlevel = 0
-  for i = 1, #MythicMaps do
-    local _, level = C_MythicPlus.GetWeeklyBestForMap(MythicMaps[i]);
-    if level then
-      if level > bestlevel then
-        bestlevel = level
-      end
-    end
-  end
   if t.MythicKeyBest and (t.MythicKeyBest.ResetTime or 0) < time() then -- dont know weekly reset function will run early or not
     if t.MythicKeyBest.level and t.MythicKeyBest.level > 0 then
       t.MythicKeyBest.LastWeekLevel = t.MythicKeyBest.level
@@ -108,7 +96,7 @@ function MythicPlusModule:RefreshMythicKeyInfo(event)
   end
   t.MythicKeyBest = t.MythicKeyBest or { }
   t.MythicKeyBest.ResetTime = addon:GetNextWeeklyResetTime()
-  t.MythicKeyBest.level = bestlevel
+  t.MythicKeyBest.level = C_MythicPlus.GetWeeklyChestRewardLevel()
   t.MythicKeyBest.WeeklyReward = C_MythicPlus.IsWeeklyRewardAvailable()
 end
 

--- a/SavedInstances/Tradeskills.lua
+++ b/SavedInstances/Tradeskills.lua
@@ -80,16 +80,16 @@ local trade_spells = {
   [247701] = "legionxmute", -- Transmute: Primal Sargerite
 
   -- BfA
-  [251832] = "legionxmute", -- Transmute: Expulsom
-  [251314] = "legionxmute", -- Transmute: Cloth to Skins
-  [251822] = "legionxmute", -- Transmute: Fish to Gems
-  [251306] = "legionxmute", -- Transmute: Herbs to Cloth
-  [251305] = "legionxmute", -- Transmute: Herbs to Ore
-  [251808] = "legionxmute", -- Transmute: Meat to Pet
-  [251310] = "legionxmute", -- Transmute: Ore to Cloth
-  [251311] = "legionxmute", -- Transmute: Ore to Gems
-  [251309] = "legionxmute", -- Transmute: Ore to Herbs
-  [286547] = "legionxmute", -- Transmute: Herbs to Anchors
+  [251832] = "xmute", -- Transmute: Expulsom
+  [251314] = "xmute", -- Transmute: Cloth to Skins
+  [251822] = "xmute", -- Transmute: Fish to Gems
+  [251306] = "xmute", -- Transmute: Herbs to Cloth
+  [251305] = "xmute", -- Transmute: Herbs to Ore
+  [251808] = "xmute", -- Transmute: Meat to Pet
+  [251310] = "xmute", -- Transmute: Ore to Cloth
+  [251311] = "xmute", -- Transmute: Ore to Gems
+  [251309] = "xmute", -- Transmute: Ore to Herbs
+  [286547] = "xmute", -- Transmute: Herbs to Anchors
 
   -- Enchanting
   [28027] = "sphere", 	-- Prismatic Sphere (2-day shared, 5.2.0 verified)

--- a/SavedInstances/WorldBosses.lua
+++ b/SavedInstances/WorldBosses.lua
@@ -51,8 +51,12 @@ addon.WorldBosses = {
   [2199] = { quest=52163, expansion=7, level=120 }, -- Azurethos
   [2198] = { quest=52166, expansion=7, level=120 }, -- Warbringer Yenajz
   [2210] = { quest=52196, expansion=7, level=120 }, -- Dunegorger Kraulok
+  -- Arathi Highlands
   [2212] = { quest=52848, expansion=7, level=120 }, -- The Lion's Roar
   [2213] = { quest=52847, expansion=7, level=120 }, -- Doom's Howl
+  -- Darkshore
+  [2329] = { quest=54896, expansion=7, level=120 }, -- Ivus the Forest Lord
+  [2345] = { quest=54895, expansion=7, level=120 }, -- Ivus the Decayed
 
   -- bosses with no EJ entry (eid is a placeholder)
   [9001] = { quest=38276, name=GARRISON_LOCATION_TOOLTIP.." "..BOSS, expansion=5, level=100 },


### PR DESCRIPTION
Note of Trade Skill Commit: In LEG, there are two different kinds of transmute: Wild Transmute and normal Transmute, and `wildxmute` and `legionxmute` are showing the difference of them which are only used in locale. In BfA, there is only one kind of transmute, so we can use the locate from old expansions.