### PR TITLE
Reworked Emissary Module

### DIFF
--- a/SavedInstances/Emissary.lua
+++ b/SavedInstances/Emissary.lua
@@ -72,12 +72,12 @@ function EmissaryModule:RefreshDailyWorldQuestInfo()
               Horde = BountyInfo.questID,
             }
           end
+          currExpansion[day].questNeed = questNeed
           currExpansion[day].expiredTime = timeleft * 60 + time()
           t.Emissary[expansionLevel].days[day] = {
             isComplete = false,
             isFinish = isFinish,
             questDone = questDone,
-            questNeed = questNeed,
           }
         end
       end

--- a/SavedInstances/Emissary.lua
+++ b/SavedInstances/Emissary.lua
@@ -28,10 +28,11 @@ local _switching = {
 local switching, k, v = {}
 for k, v in pairs(_switching) do
   local tbl = {
-    "Alliance" = k,
-    "Horde" = v,
+    Alliance = k,
+    Horde = v,
   }
-  switching[k] = switching[v] = tbl
+  switching[k] = tbl
+  switching[v] = tbl
 end
 
 function EmissaryModule:OnEnable()
@@ -67,8 +68,8 @@ function EmissaryModule:RefreshDailyWorldQuestInfo()
             currExpansion[day].questID = switching[BountyInfo.questID]
           else
             currExpansion[day].questID = {
-              "Alliance" = BountyInfo.questID,
-              "Horde" = BountyInfo.questID,
+              Alliance = BountyInfo.questID,
+              Horde = BountyInfo.questID,
             }
           end
           currExpansion[day].expiredTime = timeleft * 60 + time()

--- a/SavedInstances/Emissary.lua
+++ b/SavedInstances/Emissary.lua
@@ -3,6 +3,36 @@ local EmissaryModule = LibStub("AceAddon-3.0"):GetAddon(addonName):NewModule("Em
 local L = addon.L
 local thisToon = UnitName("player") .. " - " .. GetRealmName()
 
+local emissaries = {
+  [6] = {
+    UiMapID = 627,
+    questID = 43341,
+  },
+  [7] = {
+    UiMapID = 876,
+    questID = 51722,
+  },
+}
+
+-- [Alliance] = Horde
+local _switching = {
+  [50605] = 50606, -- Alliance War Effort / Horde War Effort
+  [50601] = 50602, -- Storm's Wake / Talanji's Expedition
+  [50599] = 50598, -- Proudmoore Admiralty / Zandalari Empire
+  [50600] = 50603, -- Order of Embers / Voldunai
+}
+
+-- Switching Table
+-- [questID] = { ["Alliance"] = questID, ["Horde"] = questID }
+local switching, k, v = {}
+for k, v in pairs(_switching) do
+  local tbl = {
+    "Alliance" = k,
+    "Horde" = v,
+  }
+  switching[k] = switching[v] = tbl
+end
+
 function EmissaryModule:OnEnable()
 	self:RegisterEvent("PLAYER_ENTERING_WORLD", "RefreshDailyWorldQuestInfo")
   self:RegisterEvent("ADDON_LOADED", "RefreshDailyWorldQuestInfo")

--- a/SavedInstances/Emissary.lua
+++ b/SavedInstances/Emissary.lua
@@ -3,7 +3,7 @@ local EmissaryModule = LibStub("AceAddon-3.0"):GetAddon(addonName):NewModule("Em
 local L = addon.L
 local thisToon = UnitName("player") .. " - " .. GetRealmName()
 
-local emissaries = {
+local Emissaries = {
   [6] = {
     UiMapID = 627,
     questID = 43341,
@@ -13,6 +13,7 @@ local emissaries = {
     questID = 51722,
   },
 }
+addon.Emissaries = Emissaries
 
 -- [Alliance] = Horde
 local _switching = {
@@ -42,58 +43,51 @@ end
 
 function EmissaryModule:RefreshDailyWorldQuestInfo()
   local t = addon.db.Toons[thisToon]
-  t.DailyWorldQuest = {}
-  local BountyQuest = GetQuestBountyInfoForMapID(876)
-  for BountyIndex, BountyInfo in ipairs(BountyQuest) do
-    local title = GetQuestLogTitle(GetQuestLogIndexByID(BountyInfo.questID))
-    local timeleft = C_TaskQuest.GetQuestTimeLeftMinutes(BountyInfo.questID)
-    local _, _, isFinish, questDone, questNeed = GetQuestObjectiveInfo(BountyInfo.questID, 1, false)
-    if timeleft then
-      if timeleft > 2880 then
-        if t.DailyWorldQuest.days2 then else t.DailyWorldQuest.days2 = {} end
-        t.DailyWorldQuest.days2.name = title
-        t.DailyWorldQuest.days2.dayleft = 2
-        t.DailyWorldQuest.days2.questneed = questNeed
-        t.DailyWorldQuest.days2.questdone = questDone
-        t.DailyWorldQuest.days2.isfinish = isFinish
-        t.DailyWorldQuest.days2.iscompleted = IsQuestFlaggedCompleted(BountyInfo.questID)
-      elseif timeleft > 1440 then
-        if t.DailyWorldQuest.days1 then else t.DailyWorldQuest.days1 = {} end
-        t.DailyWorldQuest.days1.name = title
-        t.DailyWorldQuest.days1.dayleft = 1
-        t.DailyWorldQuest.days1.questneed = questNeed
-        t.DailyWorldQuest.days1.questdone = questDone
-        t.DailyWorldQuest.days1.isfinish = isFinish
-        t.DailyWorldQuest.days1.iscompleted = IsQuestFlaggedCompleted(BountyInfo.questID)
-      else
-        if t.DailyWorldQuest.days0 then else t.DailyWorldQuest.days0 = {} end
-        t.DailyWorldQuest.days0.name = title
-        t.DailyWorldQuest.days0.dayleft = 0
-        t.DailyWorldQuest.days0.questneed = questNeed
-        t.DailyWorldQuest.days0.questdone = questDone
-        t.DailyWorldQuest.days0.isfinish = isFinish
-        t.DailyWorldQuest.days0.iscompleted = IsQuestFlaggedCompleted(BountyInfo.questID)
+  t.Emissary = {}
+  local expansionLevel, tbl
+  for expansionLevel, tbl in pairs(Emissaries) do
+    if not addon.db.Emissary.Expansion[expansionLevel] then addon.db.Emissary.Expansion[expansionLevel] = {} end
+    local currExpansion = addon.db.Emissary.Expansion[expansionLevel]
+    t.Emissary[expansionLevel] = {}
+    if IsQuestFlaggedCompleted(tbl.questID) then
+      t.Emissary[expansionLevel] = {
+        unlocked = true,
+        days = {},
+      }
+      local BountyQuest, BountyIndex, BountyInfo = GetQuestBountyInfoForMapID(tbl.UiMapID)
+      for BountyIndex, BountyInfo in ipairs(BountyQuest) do
+        local title = GetQuestLogTitle(GetQuestLogIndexByID(BountyInfo.questID))
+        local timeleft = C_TaskQuest.GetQuestTimeLeftMinutes(BountyInfo.questID)
+        local _, _, isFinish, questDone, questNeed = GetQuestObjectiveInfo(BountyInfo.questID, 1, false)
+        addon.db.Emissary.Cache[BountyInfo.questID] = title -- cache quest name
+        if timeleft then
+          local day = math.floor(timeleft / 1440) + 1 -- [1, 2, 3]
+          if not currExpansion[day] then currExpansion[day] = {} end
+          if switching[BountyInfo.questID] then
+            currExpansion[day].questID = switching[BountyInfo.questID]
+          else
+            currExpansion[day].questID = {
+              "Alliance" = BountyInfo.questID,
+              "Horde" = BountyInfo.questID,
+            }
+          end
+          currExpansion[day].expiredTime = timeleft * 60 + time()
+          t.Emissary[expansionLevel].days[day] = {
+            isComplete = false,
+            isFinish = isFinish,
+            questDone = questDone,
+            questNeed = questNeed,
+          }
+        end
       end
-    end
-  end
-  if IsQuestFlaggedCompleted(51918) or IsQuestFlaggedCompleted(51916) then -- Uniting Kul Tiras & Uniting Zandalar
-    if t.DailyWorldQuest.days0 == nil then
-      t.DailyWorldQuest.days0 = {}
-      t.DailyWorldQuest.days0.dayleft = 0
-      t.DailyWorldQuest.days0.iscompleted = true
-      t.DailyWorldQuest.days0.name = L["Emissary Missing"]
-    end
-    if t.DailyWorldQuest.days1 == nil then
-      t.DailyWorldQuest.days1 = {}
-      t.DailyWorldQuest.days1.dayleft = 1
-      t.DailyWorldQuest.days1.iscompleted = true
-      t.DailyWorldQuest.days1.name = L["Emissary Missing"]
-    end
-    if t.DailyWorldQuest.days2 == nil then
-      t.DailyWorldQuest.days2 = {}
-      t.DailyWorldQuest.days2.dayleft = 2
-      t.DailyWorldQuest.days2.iscompleted = true
-      t.DailyWorldQuest.days2.name = L["Emissary Missing"]
+      local i
+      for i = 1, 3 do
+        if not t.Emissary[expansionLevel].days[i] then
+          t.Emissary[expansionLevel].days[i] = {
+            isComplete = true,
+          }
+        end
+      end
     end
   end
 end

--- a/SavedInstances/MythicPlus.lua
+++ b/SavedInstances/MythicPlus.lua
@@ -57,7 +57,8 @@ function MythicPlusModule:RefreshMythicKeyInfo(event)
           _,_,_,color = GetItemQualityColor(2)
         else
           _,_,_,color = GetItemQualityColor(1)
-        endaddon:debug(gsub(keyLink, "\124", "\124\124"))
+        end
+        addon:debug(gsub(keyLink, "\124", "\124\124"))
         t.MythicKey.abbrev = KeystoneAbbrev[mapID]
         t.MythicKey.link = C_ChallengeMode.GetMapUIInfo(mapID)
         t.MythicKey.color = color

--- a/SavedInstances/MythicPlus.lua
+++ b/SavedInstances/MythicPlus.lua
@@ -57,29 +57,7 @@ function MythicPlusModule:RefreshMythicKeyInfo(event)
           _,_,_,color = GetItemQualityColor(2)
         else
           _,_,_,color = GetItemQualityColor(1)
-        end
-        if addon.db.Tooltip.DebugMode then
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[1]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[2]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[3]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[4]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[5]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[6]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[7]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[8]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[9]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[10]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[11]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[12]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[13]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[14]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[15]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[16]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[17]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[18]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[19]))
-          DEFAULT_CHAT_FRAME:AddMessage(tostring(KeyInfo[20]))
-        end
+        endaddon:debug(gsub(keyLink, "\124", "\124\124"))
         t.MythicKey.abbrev = KeystoneAbbrev[mapID]
         t.MythicKey.link = C_ChallengeMode.GetMapUIInfo(mapID)
         t.MythicKey.color = color

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -3865,7 +3865,7 @@ function core:ShowTooltip(anchorframe)
         if t.Emissary and t.Emissary[expansionLevel] and t.Emissary[expansionLevel].unlocked then
           local day, info
           for day, info in pairs(t.Emissary[expansionLevel].days) do
-            if addon.db.Tooltip.EmissaryShowCompleted == false or info.isComplete == false then
+            if addon.db.Tooltip.EmissaryShowCompleted == true or info.isComplete == false then
               if not show[day].first then
                 show[day].first = t.Faction
               elseif show[day].first ~= t.Faction then

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -2328,6 +2328,7 @@ function core:toonInit()
   ti.Order = ti.Order or 50
   ti.Quests = ti.Quests or {}
   ti.Skills = ti.Skills or {}
+  ti.DailyWorldQuest = nil -- REMOVED
   -- try to get a reset time, but don't overwrite existing, which could break quest list
   -- real update comes later in UpdateToonData
   ti.DailyResetTime = ti.DailyResetTime or addon:GetNextDailyResetTime()

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -3920,7 +3920,7 @@ function core:ShowTooltip(anchorframe)
               else
                 text = info.questDone
                 if (
-                  addon.db.Emissary.Expansion[expansionLevel][day] and 
+                  addon.db.Emissary.Expansion[expansionLevel][day] and
                   addon.db.Emissary.Expansion[expansionLevel][day].questNeed
                 ) then
                   text = text .. "/" .. addon.db.Emissary.Expansion[expansionLevel][day].questNeed

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -1782,7 +1782,7 @@ local function ShowEmissarySummary(cell, arg, ...)
   local day = arg
   local buffer, flag = {}, false
   openIndicator(2, "LEFT", "RIGHT")
-  indicatortip:AddHeader(L["Emissary quests"], "")
+  indicatortip:AddHeader(L["Emissary quests"], "+" .. day .. " " .. L["Day"])
   local toon, t
   for toon, t in pairs(addon.db.Toons) do
     local info = t.DailyWorldQuest["days" .. day]

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -3865,7 +3865,7 @@ function core:ShowTooltip(anchorframe)
         if t.Emissary and t.Emissary[expansionLevel] and t.Emissary[expansionLevel].unlocked then
           local day, info
           for day, info in pairs(t.Emissary[expansionLevel].days) do
-            if addon.db.Tooltip.EmissaryShowCompleted == true or info.isComplete == false then
+            if showall or addon.db.Tooltip.EmissaryShowCompleted == true or info.isComplete == false then
               if not show[day].first then
                 show[day].first = t.Faction
               elseif show[day].first ~= t.Faction then

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -1503,7 +1503,7 @@ function addon:UpdateToonData()
         end
         if ti.Emissary then
           local expansionLevel, tbl
-          for expansionLevel, tbl in (ti.Emissary) do
+          for expansionLevel, tbl in pairs(ti.Emissary) do
             if tbl.unlocked then
               tbl.days[1] = tbl.days[2]
               tbl.days[2] = tbl.days[3]
@@ -3919,7 +3919,10 @@ function core:ShowTooltip(anchorframe)
                 text = "\124T"..READY_CHECK_WAITING_TEXTURE..":0|t"
               else
                 text = info.questDone
-                if addon.db.Emissary.Expansion[expansionLevel][day].questNeed then
+                if (
+                  addon.db.Emissary.Expansion[expansionLevel][day] and 
+                  addon.db.Emissary.Expansion[expansionLevel][day].questNeed
+                ) then
                   text = text .. "/" .. addon.db.Emissary.Expansion[expansionLevel][day].questNeed
                 end
               end

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -1884,7 +1884,11 @@ local function ShowEmissarySummary(cell, arg, ...)
           local info = t.Emissary and t.Emissary[expansionLevel] and t.Emissary[expansionLevel].days[day]
           if info then
             if header == false then
-              indicatortip:AddLine(addon.db.Emissary.Cache[addon.db.Emissary.Expansion[expansionLevel][day].questID.Alliance])
+              local name = addon.db.Emissary.Cache[addon.db.Emissary.Expansion[expansionLevel][day].questID[fac]]
+              if not name then
+                name = L["Emissary Missing"]
+              end
+              indicatortip:AddLine(name)
               header = true
             end
             local text
@@ -3881,7 +3885,9 @@ function core:ShowTooltip(anchorframe)
         local name = addon.db.Emissary.Cache[questID]
         if addon.db.Tooltip.EmissaryFullName and show[day].second then
           local questID = addon.db.Emissary.Expansion[7][day].questID[show[day].second]
-          name = name .. " / " .. addon.db.Emissary.Cache[questID]
+          if addon.db.Emissary.Cache[questID] then
+            name = name .. " / " .. addon.db.Emissary.Cache[questID]
+          end
         end
         tooltips[day] = tooltip:AddLine(GOLDFONT .. name .. " (+" .. day .. " " .. L["Day"] .. ")" .. FONTEND)
         tooltip:SetCellScript(tooltips[day], 1, "OnEnter", ShowEmissarySummary, {7, day})

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -3896,8 +3896,8 @@ function core:ShowTooltip(anchorframe)
             name = addon.db.Emissary.Cache[questID]
             if addon.db.Tooltip.EmissaryFullName and show[day].second then
               local secondQuestID = addon.db.Emissary.Expansion[expansionLevel][day].questID[show[day].second]
-              if secondQuestID ~= questID and addon.db.Emissary.Cache[questID] then
-                name = name .. " / " .. addon.db.Emissary.Cache[questID]
+              if secondQuestID ~= questID and addon.db.Emissary.Cache[secondQuestID] then
+                name = name .. " / " .. addon.db.Emissary.Cache[secondQuestID]
               end
             end
           end

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -312,17 +312,33 @@ addon.defaultDB = {
   -- level: string
   -- color: string
   -- link: string
+
   -- MythicKeyBest
   -- lastweeklevel: int
   -- ResetTime: expiry
   -- level: string
   -- weeklyReward: boolean
+
+  -- REMOVED
   -- DailyWorldQuest
   -- days[0,1,2]
   -- name
   -- dayleft
   -- questneed
   -- questdone
+
+  -- Emissary
+  -- [expansionLevel] = {
+  --   unlocked = (boolean),
+  --   days = {
+  --     [Day] = {
+  --       isFinish = isFinish,
+  --       questDone = questDone,
+  --       questNeed = questNeed,
+  --       expiredTime = expiredTime,
+  --     },
+  --   },
+  -- }
 
   Indicators = {
     D1Indicator = "BLANK", -- indicator: ICON_*, BLANK
@@ -421,8 +437,9 @@ addon.defaultDB = {
     CurrencyEarned = true,
     MythicKey = true,
     MythicKeyBest = true,
-    DailyWorldQuest = true,
-    DailyWorldQuestAllNames = true,
+    Emissary6 = false, -- LEG Emissary
+    Emissary7 = true, -- BfA Emissary
+    EmissaryFullName = true,
     AbbreviateKeystone = true,
   },
   Instances = { }, 	-- table key: "Instance name"; value:
@@ -453,6 +470,22 @@ addon.defaultDB = {
     AccountDaily = {},
     AccountWeekly = {},
   },
+  Emissary = {
+    Cache = {},
+    Expansion = {},
+  },
+  -- Track emissaries
+  -- Cache: [questID] = questName
+  -- Expansion:
+  -- [expansionLevel] = {
+  --   [1, 2, 3] = {
+  --     questID = {
+  --       ["Alliance"] = questID,
+  --       ["Horde"] = questID,
+  --     },
+  --     expiredTime = expiredTime
+  --   }
+  -- }
   RealmMap = {},
 }
 

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -62,6 +62,7 @@ local QuestExceptions = addon.QuestExceptions
 local scantt = addon.scantt
 local KeystonetoAbbrev = addon.KeystonetoAbbrev
 local KeystoneAbbrev = addon.KeystoneAbbrev
+local Emissaries = addon.Emissaries
 
 addon.Indicators = {
   ICON_STAR = ICON_LIST[1] .. "16:16:0:0|t",
@@ -332,6 +333,7 @@ addon.defaultDB = {
   --   unlocked = (boolean),
   --   days = {
   --     [Day] = {
+  --       isComplete = isComplete
   --       isFinish = isFinish,
   --       questDone = questDone,
   --       questNeed = questNeed,
@@ -1465,16 +1467,18 @@ function addon:UpdateToonData()
             ti.Quests[id] = nil
           end
         end
-        if ti.DailyWorldQuest then
-          if ti.DailyWorldQuest.days1 then
-            ti.DailyWorldQuest.days0 = ti.DailyWorldQuest.days1
-            ti.DailyWorldQuest.days0.dayleft = 0
-            ti.DailyWorldQuest.days1 = nil
-          end
-          if ti.DailyWorldQuest.days2 then
-            ti.DailyWorldQuest.days1 = ti.DailyWorldQuest.days2
-            ti.DailyWorldQuest.days1.dayleft = 1
-            ti.DailyWorldQuest.days2 = nil
+        if ti.Emissary then
+          local expansionLevel, tbl
+          for expansionLevel, tbl in (ti.Emissary) do
+            if tbl.unlocked then
+              tbl.days[1] = tbl.days[2]
+              tbl.days[2] = tbl.days[3]
+              tbl.days[3] = {
+                isComplete = false,
+                isFinish = false,
+                questDone = 0,
+              }
+            end
           end
         end
         ti.DailyResetTime = (ti.DailyResetTime and ti.DailyResetTime + 24*3600) or nextreset
@@ -1486,6 +1490,14 @@ function addon:UpdateToonData()
         if qi.isDaily then
           db.Quests[id] = nil
         end
+    end
+    if addon.db.Emissary and addon.db.Emissary.Expansion then
+      local expansionLevel, tbl
+      for expansionLevel, tbl in pairs(addon.db.Emissary.Expansion) do
+        tbl[1] = tbl[2]
+        tbl[2] = tbl[3]
+        tbl[3] = nil
+      end
     end
     db.DailyResetTime = nextreset
     end
@@ -1545,7 +1557,7 @@ function addon:UpdateToonData()
   for id,qi in pairs(db.Quests) do -- AccountWeekly reset
     if not qi.isDaily and (qi.Expires or 0) < time() then
       db.Quests[id] = nil
-  end
+    end
   end
   addon:UpdateCurrency()
   local zone = GetRealZoneText()
@@ -1812,34 +1824,49 @@ local function ShowSkillTooltip(cell, arg, ...)
 end
 
 local function ShowEmissarySummary(cell, arg, ...)
-  local day = arg
-  local buffer, flag = {}, false
+  local expansionLevel, day = unpack(arg)
+  local tbl, questNeed = {}
+  local cache, buffer, flag = {}, {}, false
   openIndicator(2, "LEFT", "RIGHT")
   indicatortip:AddHeader(L["Emissary quests"], "+" .. day .. " " .. L["Day"])
   local toon, t
   for toon, t in pairs(addon.db.Toons) do
-    local info = t.DailyWorldQuest["days" .. day]
-    if info and not info.iscompleted then
-      if not buffer[info.name] then buffer[info.name] = {} end
-      table.insert(buffer[info.name], toon)
-      flag = true
+    local info = t.Emissary and t.Emissary[expansionLevel] and t.Emissary[expansionLevel].days[day]
+    if info and info.questNeed then
+      questNeed = info.questNeed
     end
+    tbl[t.Faction] = true
   end
-  if not flag then
+  if not tbl.Alliance and not tbl.Horde then
     indicatortip:AddLine(L["Emissary Missing"], "")
   else
-    local name, tbl
-    for name, tbl in pairs(buffer) do
-      indicatortip:AddLine(name, "")
-      for _, toon in pairs(tbl) do
-        t = addon.db.Toons[toon]
-        local info, str = t.DailyWorldQuest["days" .. day]
-        if info.isfinish then
-          str = "\124T"..READY_CHECK_WAITING_TEXTURE..":0|t"
-        else
-          str = info.questdone .. "/" .. info.questneed
+    local fac
+    for fac, _ in pairs(tbl) do
+      local header, toon, t = false
+      for toon, t in pairs(addon.db.Toons) do
+        if t.Faction == fac then
+          local info = t.Emissary and t.Emissary[expansionLevel] and t.Emissary[expansionLevel].days[day]
+          if info then
+            if header == false then
+              indicatortip:AddLine(addon.db.Emissary.Cache[addon.db.Emissary.Expansion[expansionLevel][day].questID.Alliance])
+              header = true
+            end
+            local text
+            if info.isComplete == true then
+              text = "\124T"..READY_CHECK_READY_TEXTURE..":0|t"
+            elseif info.isFinish == true then
+              text = "\124T"..READY_CHECK_WAITING_TEXTURE..":0|t"
+            else
+              text = info.questDone
+              if info.questNeed then
+                text = text .. "/" .. info.questNeed
+              elseif questNeed then
+                text = text .. "/" .. questNeed
+              end
+            end
+            indicatortip:AddLine(ClassColorise(t.Class, toon), str)
+          end
         end
-        indicatortip:AddLine(ClassColorise(t.Class, toon), str)
       end
     end
   end
@@ -3776,55 +3803,73 @@ function core:ShowTooltip(anchorframe)
     end
   end
 
-  if addon.db.Tooltip.DailyWorldQuest or showall then
-    local show = {}
+  if addon.db.Tooltip.Emissary7 or showall then
+    local show, tooltips = {
+      [1] = {},
+      [2] = {},
+      [3] = {},
+    }, {}
     for toon, t in cpairs(addon.db.Toons, true) do
-      if t.DailyWorldQuest then
-        for day,DailyInfo in pairs(t.DailyWorldQuest) do
-          if DailyInfo.name then
-            if(not show[DailyInfo.dayleft] or show[DailyInfo.dayleft] == L["Emissary Missing"]) then
-              show[DailyInfo.dayleft] = DailyInfo.name
-            elseif (
-              addon.db.Tooltip.DailyWorldQuestAllNames and
-              (not show[DailyInfo.dayleft]:find("/")) and
-              (show[DailyInfo.dayleft] ~= DailyInfo.name) and
-              (DailyInfo.name ~= L["Emissary Missing"])
-            ) then
-              -- shows both factions emissary name
-              show[DailyInfo.dayleft] = show[DailyInfo.dayleft] .. " / " .. DailyInfo.name
+      if t.Emissary and t.Emissary[7] and t.Emissary[7].unlocked then
+        local day, info
+        for day, info in pairs(t.Emissary[7].days) do
+          if not info.isFinish then
+            if not show[day].first then
+              show[day].first = t.Faction
+            elseif show[day].first ~= t.Faction then
+              show[day].second = t.Faction
             end
-            addColumns(columns, toon, tooltip)
+            -- Auto fill other toon's questNeed
+            if info.questNeed then
+              show[day].questNeed = info.questNeed
+            end
           end
         end
+        addColumns(columns, toon, tooltip)
       end
     end
 
     if not firstcategory and addon.db.Tooltip.CategorySpaces then
-            addsep()
+      addsep()
     end
     if addon.db.Tooltip.ShowCategories then
       tooltip:AddLine(YELLOWFONT .. L["Emissary Quests"] .. FONTEND)
     end
-    for dayleft = 0 , 2 do
-      if show[dayleft] then
-        local showday = show[dayleft]
-			  show[dayleft] = tooltip:AddLine(GOLDFONT .. showday .. " (+" .. dayleft .. " " .. L["Day"] .. ")" .. FONTEND)
-        tooltip:SetCellScript(show[dayleft], 1, "OnEnter", ShowEmissarySummary, dayleft)
-        tooltip:SetCellScript(show[dayleft], 1, "OnLeave", CloseTooltips)
+
+    local day, tbl
+    for day, tbl in pairs(show) then
+      if show[day].first then
+        local questID = addon.db.Emissary.Expansion[7][day].questID[show[day].first]
+        local name = addon.db.Emissary.Cache[questID]
+        if addon.db.Tooltip.EmissaryFullName and show[day].second then
+          local questID = addon.db.Emissary.Expansion[7][day].questID[show[day].second]
+          name = name .. " / " .. addon.db.Emissary.Cache[questID]
+        end
+        tooltips[day] = tooltip:AddLine(GOLDFONT .. name .. " (+" .. day .. " " .. L["Day"] .. ")" .. FONTEND)
+        tooltip:SetCellScript(tooltips[day], 1, "OnEnter", ShowEmissarySummary, {7, day})
+        tooltip:SetCellScript(tooltips[day], 1, "OnLeave", CloseTooltips)
       end
     end
+
     for toon, t in cpairs(addon.db.Toons, true) do
-      if t.DailyWorldQuest then
-        for day,DailyInfo in pairs(t.DailyWorldQuest) do
-          if show[DailyInfo.dayleft] then
-            local col = columns[toon..1]
-            if DailyInfo.iscompleted == true then
-              tooltip:SetCell(show[DailyInfo.dayleft], col, "\124T"..READY_CHECK_READY_TEXTURE..":0|t", "CENTER", maxcol)
-            elseif DailyInfo.isfinish == true then
-              tooltip:SetCell(show[DailyInfo.dayleft], col, "\124T"..READY_CHECK_WAITING_TEXTURE..":0|t", "CENTER", maxcol)
+      if t.Emissary and t.Emissary[7] and t.Emissary[7].unlocked then
+        local day, info
+        for day, info in pairs(t.Emissary[7].days) do
+          if tooltips[day] then
+            local col, text = columns[toon..1]
+            if info.isComplete == true then
+              text = "\124T"..READY_CHECK_READY_TEXTURE..":0|t"
+            elseif info.isFinish == true then
+              text = "\124T"..READY_CHECK_WAITING_TEXTURE..":0|t"
             else
-              tooltip:SetCell(show[DailyInfo.dayleft], col, DailyInfo.questdone .. "/" .. DailyInfo.questneed , "CENTER",maxcol)
+              text = info.questDone
+              if info.questNeed then
+                text = text .. "/" .. info.questNeed
+              elseif show[day].questNeed then
+                text = text .. "/" .. show[day].questNeed
+              end
             end
+            tooltip:SetCell(tooltips[day], col, text, "CENTER", maxcol)
           end
         end
       end

--- a/SavedInstances/config.lua
+++ b/SavedInstances/config.lua
@@ -360,81 +360,79 @@ function module:BuildOptions()
             desc = L["Combine LFR"],
             order = 23.95,
           },
-          MiscHeader = {
+          EmissaryHeader = {
             order = 30,
+            type = "header",
+            name = L["Emissary quests"],
+          },
+          EmissaryFullName = {
+            type = "toggle",
+            order = 39.1,
+            name = L["Show all emissary names"],
+            desc = L["Show both factions' emissay name"],
+          },
+          EmissaryShowCompleted = {
+            type = "toggle",
+            order = 39.2,
+            name = L["Show when completed"],
+            desc = L["Show emissary line when all quests completed"],
+          },
+          MiscHeader = {
+            order = 40,
             type = "header",
             name = L["Miscellaneous Tracking"],
           },
           TrackDailyQuests = {
             type = "toggle",
-            order = 33,
+            order = 43,
             name = L["Daily Quests"],
           },
           TrackWeeklyQuests = {
             type = "toggle",
-            order = 33.5,
+            order = 43.5,
             name = L["Weekly Quests"],
-          },
-          --[[
-          Emissary6 = {
-            type = "toggle",
-            order = 33.60,
-            name = EXPANSION_NAME6 .. L["Emissary quests"],
-          },
-          --]]
-          Emissary7 = {
-            type = "toggle",
-            order = 33.61,
-            -- name = EXPANSION_NAME7 .. L["Emissary quests"],
-            name = L["Emissary quests"],
-          },
-          EmissaryFullName = {
-            type = "toggle",
-            order = 33.69,
-            name = L["Show all emissary names"],
-            desc = L["Show both factions' emissay name"],
           },
           TrackSkills = {
             type = "toggle",
-            order = 33.7,
+            order = 43.7,
             name = L["Trade skills"],
           },
           TrackBonus = {
             type = "toggle",
-            order = 33.8,
+            order = 43.8,
             name = L["Bonus rolls"],
           },
           AugmentBonus = {
             type = "toggle",
-            order = 33.9,
+            order = 43.9,
             name = L["Bonus loot frame"],
           },
           TrackLFG = {
             type = "toggle",
-            order = 34,
+            order = 44,
             name = L["LFG cooldown"],
             desc = L["Show cooldown for characters to use LFG dungeon system"],
           },
           TrackDeserter = {
             type = "toggle",
-            order = 35,
+            order = 45,
             name = L["Battleground Deserter"],
             desc = L["Show cooldown for characters to use battleground system"],
           },
           TrackPlayed = {
             type = "toggle",
-            order = 36,
+            order = 46,
             name = L["Time /played"],
           },
           MythicKey = {
             type = "toggle",
-            order = 37,
+            order = 47,
             name = L["Mythic Keystone"],
             desc = L["Track Mythic keystone acquisition"],
           },
           MythicKeyBest = {
             type = "toggle",
-            order = 37.5,
+            order = 47.5,
             name = L["Mythic Best"],
             desc = L["Track Mythic keystone best run"],
           },
@@ -820,6 +818,14 @@ function module:BuildOptions()
   core.Options = core.Options or {} -- allow option table rebuild
   for k,v in pairs(opts) do
     core.Options[k] = v
+  end
+  local expansion
+  for expansion, _ in pairs(SavedInstances.Emissaries) do
+    core.Options.args.General.args["Emissary" .. expansion] = {
+      type = "toggle",
+      order = 31 + expansion * 0.1,
+      name = _G["EXPANSION_NAME" .. expansion],
+    }
   end
   for i, curr in ipairs(SavedInstances.currency) do
     local name,_,tex = GetCurrencyInfo(curr)

--- a/SavedInstances/config.lua
+++ b/SavedInstances/config.lua
@@ -375,15 +375,18 @@ function module:BuildOptions()
             order = 33.5,
             name = L["Weekly Quests"],
           },
+          --[[
           Emissary6 = {
             type = "toggle",
             order = 33.60,
             name = EXPANSION_NAME6 .. L["Emissary quests"],
           },
+          --]]
           Emissary7 = {
             type = "toggle",
             order = 33.61,
-            name = EXPANSION_NAME7 .. L["Emissary quests"],
+            -- name = EXPANSION_NAME7 .. L["Emissary quests"],
+            name = L["Emissary quests"],
           },
           EmissaryFullName = {
             type = "toggle",

--- a/SavedInstances/config.lua
+++ b/SavedInstances/config.lua
@@ -375,14 +375,19 @@ function module:BuildOptions()
             order = 33.5,
             name = L["Weekly Quests"],
           },
-          DailyWorldQuest = {
+          Emissary6 = {
             type = "toggle",
-            order = 33.6,
-            name = L["Emissary quests"],
+            order = 33.60,
+            name = EXPANSION_NAME6 .. L["Emissary quests"],
           },
-          DailyWorldQuestAllNames = {
+          Emissary7 = {
             type = "toggle",
-            order = 33.65,
+            order = 33.61,
+            name = EXPANSION_NAME7 .. L["Emissary quests"],
+          },
+          EmissaryFullName = {
+            type = "toggle",
+            order = 33.69,
             name = L["Show all emissary names"],
             desc = L["Show both factions' emissay name"],
           },


### PR DESCRIPTION
* Mainly from #175 but not combined lines 
* Stored shared information like `questID` and `questNeed` in `db.Emissary`, and toon related in `db.Toon[toonName].Emissary`.
* Able to predict other toon's emissary quests.