### PR TITLE
Several Updates

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1260,7 +1260,6 @@ globals = {
 	"CalendarEventSortInvites",
 	"CalendarEventTentative",
 	"CalendarGetAbsMonth",
-	"C_Calendar.GetDate",
 	"CalendarGetDayEvent",
 	"CalendarGetDayEventSequenceInfo",
 	"CalendarGetEventIndex",

--- a/SavedInstances/Emissary.lua
+++ b/SavedInstances/Emissary.lua
@@ -78,6 +78,7 @@ function EmissaryModule:RefreshDailyWorldQuestInfo()
           currExpansion[day].questNeed = questNeed
           currExpansion[day].expiredTime = timeleft * 60 + time()
           local tbl = t.Emissary[expansionLevel].days[day]
+          tbl.expiredTime = timeleft * 60 + time()
           tbl.isComplete = false
           tbl.isFinish = isFinish
           tbl.questDone = questDone

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -721,8 +721,14 @@ function addon:QuestCount(toonname)
   -- ticket 96: GetDailyQuestsCompleted() is unreliable, the response is laggy and it fails to count some quests
   local id, info
   for id, info in pairs(t.Quests) do
-    -- Timewalking Item Quests only show during Timewalking Weeks
-    if (not TimewalkingItemQuest[id]) or eventInfo[TimewalkingItemQuest[id]] then
+    if (TimewalkingItemQuest[id] and (not eventInfo[TimewalkingItemQuest[id]])) then
+      -- Timewalking Item Quests only show during Timewalking Weeks
+    elseif (
+      (t.Faction == "Alliance" and id == 53435) or
+      (t.Faction == "Horde" and id == 53436)
+    ) then
+      -- Island Expeditions Weekly Quest (Issue #208)
+    else
       if info.isDaily then
         dailycount = dailycount + 1
       else
@@ -1822,8 +1828,14 @@ hoverTooltip.ShowQuestTooltip = function (cell, arg, ...)
   local zonename, id
   for id,qi in pairs(t.Quests) do
     if (not isDaily) == (not qi.isDaily) then
-      -- Timewalking Item Quests only show during Timewalking Weeks
-      if (not TimewalkingItemQuest[id]) or eventInfo[TimewalkingItemQuest[id]] then
+      if (TimewalkingItemQuest[id] and (not eventInfo[TimewalkingItemQuest[id]])) then
+        -- Timewalking Item Quests only show during Timewalking Weeks
+      elseif (
+        (t.Faction == "Alliance" and id == 53435) or
+        (t.Faction == "Horde" and id == 53436)
+      ) then
+        -- Island Expeditions Weekly Quest (Issue #208)
+      else
         zonename = qi.Zone and qi.Zone.name or ""
         table.insert(ql,zonename.." # "..id)
       end

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -1962,7 +1962,7 @@ hoverTooltip.ShowEmissaryTooltip = function (cell, arg, ...)
   local info = db.Toons[toon].Emissary[expansionLevel].days[day]
   if not info then return end
   openIndicator(2, "LEFT", "RIGHT")
-  local globalInfo = addon.db.Emissary.Expansion[expansionLevel][day]
+  local globalInfo = addon.db.Emissary.Expansion[expansionLevel][day] or {}
   local text
   if info.isComplete == true then
     text = "\124T"..READY_CHECK_READY_TEXTURE..":0|t"

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -499,8 +499,8 @@ addon.defaultDB = {
   --       ["Alliance"] = questID,
   --       ["Horde"] = questID,
   --     },
-  --     questNeed = questNeed
-  --     expiredTime = expiredTime
+  --     questNeed = questNeed,
+  --     expiredTime = expiredTime,
   --   }
   -- }
   RealmMap = {},

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -596,7 +596,7 @@ end
 -- convert local time -> server time: add this value
 -- convert server time -> local time: subtract this value
 function addon:GetServerOffset()
-  local serverDate = C_Calendar.GetDate() -- 1-based starts on Sun
+  local serverDate = C_DateAndTime.GetCurrentCalendarTime() -- 1-based starts on Sun
   local serverDay, serverWeekday, serverMonth, serverMinute, serverHour, serverYear = serverDate.monthDay, serverDate.weekday, serverDate.month, serverDate.minute, serverDate.hour, serverDate.year
   -- #211: date("%w") is 0-based starts on Sun
   local localDay = tonumber(date("%w")) + 1


### PR DESCRIPTION
* Remove `C_Calendar.GetDate` according to [API deprecated in 8.1.0](https://github.com/tomrus88/BlizzardInterfaceCode/blob/master/Interface/AddOns/Blizzard_Deprecated/Deprecated_8_1_0.lua)
* Add `expiredTime` in toon's data, and get ready to emissary daily reset update
* Ignore other faction's island expedition weekly quest (#208 )
* Fix nil error when rending a emissary that is not ready yet