### PR TITLE
Fix LFRs

### DIFF
--- a/SavedInstances/LFR.lua
+++ b/SavedInstances/LFR.lua
@@ -1,91 +1,97 @@
 local addonName, addon = ...
 local LFRModule = LibStub("AceAddon-3.0"):GetAddon(addonName):NewModule("LFR")
 
-addon.LFRInstances = {
+local LFRInstances = {
   -- index is the id found in LFGDungeons.dbc or using the command below.
   -- /script local id,name; for i=1,GetNumRFDungeons() do id,name = GetRFDungeonInfo(i);print(i..". "..name.." ("..id..")");end
   -- total is boss count, base is boss offset,
   -- parent is instance name to use, GetLFGDungeonInfo() or using the command below.
   -- /run for i, v in ipairs(GetLFRChoiceOrder()) do print(i, v, GetLFGDungeonInfo(v)) end
-  -- altid is for alternate LFRID for higher level toons
+  -- altid is for alternate LFRID for higher level toons, use the command below
+  -- /run for i = 1, 1951 do local _, _, _, _, maxLvl = GetLFGDungeonInfo(i) if maxLvl == 255 then print(i, GetLFGDungeonInfo(i)) end end
 
   -- Cataclysm
   [416] = { total=4, base=1,  parent=448, altid=843 }, -- DS1: The Siege of Wyrmrest Temple
   [417] = { total=4, base=5,  parent=448, altid=844 }, -- DS2: Fall of Deathwing
 
   -- Mist of Pandaria
-  [527] = { total=3, base=1,  parent=532, altid=830 }, -- MSV1: Guardians of Mogu'shan
-  [528] = { total=3, base=4,  parent=532, altid=831 }, -- MSV2: The Vault of Mysteries
-  [529] = { total=3, base=1,  parent=534, altid=832 }, -- HoF1: The Dread Approach
-  [530] = { total=3, base=4,  parent=534, altid=833 }, -- HoF2: Nightmare of Shek'zeer
+  [527] = { total=3, base=1,  parent=532, altid=830, remap={ 1, 2, 3 } }, -- MSV1: Guardians of Mogu'shan
+  [528] = { total=3, base=4,  parent=532, altid=831, remap={ 1, 2, 3 } }, -- MSV2: The Vault of Mysteries
+
+  [529] = { total=3, base=1,  parent=534, altid=832, remap={ 1, 2, 3 } }, -- HoF1: The Dread Approach
+  [530] = { total=3, base=4,  parent=534, altid=833, remap={ 1, 2, 3 } }, -- HoF2: Nightmare of Shek'zeer
+
   [526] = { total=4, base=1,  parent=536, altid=834 }, -- TeS1: Terrace of Endless Spring
-  [610] = { total=3, base=1,  parent=634, altid=835 }, -- ToT1: Last Stand of the Zandalari
-  [611] = { total=3, base=4,  parent=634, altid=836 }, -- ToT2: Forgotten Depths
-  [612] = { total=3, base=7,  parent=634, altid=837 }, -- ToT3: Halls of Flesh-Shaping
-  [613] = { total=3, base=10, parent=634, altid=838 }, -- ToT4: Pinnacle of Storms
-  [716] = { total=4, base=1,  parent=766, altid=839 }, -- SoO1: Vale of Eternal Sorrows
-  [717] = { total=4, base=5,  parent=766, altid=840 }, -- SoO2: Gates of Retribution
-  [724] = { total=3, base=9,  parent=766, altid=841 }, -- SoO3: The Underhold
-  [725] = { total=3, base=12, parent=766, altid=842 }, -- SoO4: Downfall
+
+  [610] = { total=3, base=1,  parent=634, altid=835, remap={ 1, 2, 3 } }, -- ToT1: Last Stand of the Zandalari
+  [611] = { total=3, base=4,  parent=634, altid=836, remap={ 1, 2, 3 } }, -- ToT2: Forgotten Depths
+  [612] = { total=3, base=7,  parent=634, altid=837, remap={ 1, 2, 3 } }, -- ToT3: Halls of Flesh-Shaping
+  [613] = { total=3, base=10, parent=634, altid=838, remap={ 1, 2, 3 } }, -- ToT4: Pinnacle of Storms
+
+  [716] = { total=4, base=1,  parent=766, altid=839, remap={ 1, 2, 3, 4 } }, -- SoO1: Vale of Eternal Sorrows
+  [717] = { total=4, base=5,  parent=766, altid=840, remap={ 1, 2, 3, 4 } }, -- SoO2: Gates of Retribution
+  [724] = { total=3, base=9,  parent=766, altid=841, remap={ 1, 2, 3 } }, -- SoO3: The Underhold
+  [725] = { total=3, base=12, parent=766, altid=842, remap={ 1, 2, 3 } }, -- SoO4: Downfall
 
   -- Warlords of Draenor
-  [849] = { total=3, base=1,  parent=897, altid=1363 }, -- Highmaul1: Walled City
-  [850] = { total=3, base=4,  parent=897, altid=1364 }, -- Highmaul2: Arcane Sanctum
-  [851] = { total=1, base=7,  parent=897, altid=1365 }, -- Highmaul3: Imperator's Rise
-  [847] = { total=3, base=1,  parent=900, altid=1361, remap={ 1, 2, 7 } }, -- BRF1: Slagworks
-  [846] = { total=3, base=4,  parent=900, altid=1360, remap={ 3, 5, 8 } }, -- BRF2: The Black Forge
-  [848] = { total=3, base=7,  parent=900, altid=1362, remap={ 4, 6, 9 } }, -- BRF3: Iron Assembly
-  [823] = { total=1, base=10, parent=900, altid=1359 }, -- BRF4: Blackhand's Crucible
+  [849] = { total=3, base=1,  parent=897, altid=1363, remap={ 1, 2, 3 } }, -- Highmaul1: Walled City
+  [850] = { total=3, base=4,  parent=897, altid=1364, remap={ 1, 2, 3 } }, -- Highmaul2: Arcane Sanctum
+  [851] = { total=1, base=7,  parent=897, altid=1365, remap={ 1 } }, -- Highmaul3: Imperator's Rise
 
-  [982] = { total=3, base=1,  parent=989, altid=1366 }, -- Hellfire1: Hellbreach
-  [983] = { total=3, base=4,  parent=989, altid=1367 }, -- Hellfire2: Halls of Blood
-  [984] = { total=3, base=7,  parent=989, altid=1368, remap={ 7, 8,  11 } }, -- Hellfire3: Bastion of Shadows
-  [985] = { total=3, base=10, parent=989, altid=1369, remap={ 9, 10, 12 } }, -- Hellfire4: Destructor's Rise
-  [986] = { total=1, base=13, parent=989, altid=1370 }, -- Hellfire5: The Black Gate
+  [847] = { total=3, base=1,  parent=900, altid=1361, remap={ 1, 2, 3 } }, -- BRF1: Slagworks
+  [846] = { total=3, base=4,  parent=900, altid=1360, remap={ 1, 2, 3 } }, -- BRF2: The Black Forge
+  [848] = { total=3, base=7,  parent=900, altid=1362, remap={ 1, 2, 3 } }, -- BRF3: Iron Assembly
+  [823] = { total=1, base=10, parent=900, altid=1359, remap={ 1 } }, -- BRF4: Blackhand's Crucible
+
+  [982] = { total=3, base=1,  parent=989, altid=1366, remap={ 1, 2, 3 } }, -- Hellfire1: Hellbreach
+  [983] = { total=3, base=4,  parent=989, altid=1367, remap={ 1, 2, 3 } }, -- Hellfire2: Halls of Blood
+  [984] = { total=3, base=7,  parent=989, altid=1368, remap={ 1, 2, 3 } }, -- Hellfire3: Bastion of Shadows
+  [985] = { total=3, base=10, parent=989, altid=1369, remap={ 1, 2, 3 } }, -- Hellfire4: Destructor's Rise
+  [986] = { total=1, base=13, parent=989, altid=1370, remap={ 1 } }, -- Hellfire5: The Black Gate
 
   -- Legion
-  [1287] = { total=3, base=1,  parent=1350, altid=nil, remap={ 1, 2, 3 } }, -- EN1: Darkbough
-  [1288] = { total=3, base=4,  parent=1350, altid=nil, remap={ 1, 2, 3 } }, -- EN2: Tormented Guardians
-  [1289] = { total=1, base=7,  parent=1350, altid=nil, remap={ 1 } },       -- EN3: Rift of Aln
+  [1287] = { total=3, base=1,  parent=1350, altid=1912, remap={ 1, 2, 3 } }, -- EN1: Darkbough
+  [1288] = { total=3, base=4,  parent=1350, altid=1927, remap={ 1, 2, 3 } }, -- EN2: Tormented Guardians
+  [1289] = { total=1, base=7,  parent=1350, altid=1926, remap={ 1 } },       -- EN3: Rift of Aln
 
-  [1411] = { total=3, base=1,  parent=1439, altid=nil }, -- ToV
+  [1290] = { total=3, base=1,  parent=1353, altid=1925, remap={ 1, 2, 3 } }, -- NH1: Arcing Aqueducts
+  [1291] = { total=3, base=4,  parent=1353, altid=1924, remap={ 1, 2, 3 } }, -- NH2: Royal Athenaeum
+  [1292] = { total=3, base=7,  parent=1353, altid=1923, remap={ 1, 2, 3 } }, -- NH3: Nightspire
+  [1293] = { total=1, base=10, parent=1353, altid=1922, remap={ 1 } }, -- NH4: Betrayer's Rise
 
-  [1290] = { total=3, base=1,  parent=1353, altid=nil }, -- NH1: Arcing Aqueducts
-  [1291] = { total=3, base=4,  parent=1353, altid=nil, remap={ 1, 2, 3 } }, -- NH2: Royal Athenaeum
-  [1292] = { total=3, base=7,  parent=1353, altid=nil, remap={ 1, 2, 3 } }, -- NH3: Nightspire
-  [1293] = { total=1, base=10, parent=1353, altid=nil, remap={ 1 } }, -- NH4: Betrayer's Rise
+  [1411] = { total=3, base=1,  parent=1439, altid=1921 }, -- ToV
 
-  [1494] = { total=3, base=1, parent=1527, altid=nil, remap={ 1, 2, 3 } }, -- ToS1: The Gates of Hell (6/27/17)
-  [1495] = { total=3, base=4, parent=1527, altid=nil, remap={ 1, 2, 3 } }, -- ToS2: Wailing Halls (7/11/17)
-  [1496] = { total=2, base=7, parent=1527, altid=nil, remap={ 1, 2 } }, -- ToS3: Chamber of the Avatar (7/25/17)
-  [1497] = { total=1, base=9, parent=1527, altid=nil, remap={ 1 } }, -- ToS4: Deceiver's Fall (8/8/17)
+  [1494] = { total=3, base=1,  parent=1527, altid=1920, remap={ 1, 2, 3 } }, -- ToS1: The Gates of Hell
+  [1495] = { total=3, base=4,  parent=1527, altid=1919, remap={ 1, 2, 3 } }, -- ToS2: Wailing Halls
+  [1496] = { total=2, base=7,  parent=1527, altid=1918, remap={ 1, 2 } }, -- ToS3: Chamber of the Avatar
+  [1497] = { total=1, base=9,  parent=1527, altid=1917, remap={ 1 } }, -- ToS4: Deceiver's Fall
 
-  [1610] = { total=3, base=1, parent=1642, altid=nil, remap={ 1, 2, 3 } }, -- Antorus: Light's Breach
-  [1611] = { total=3, base=4, parent=1642, altid=nil, remap={ 1, 2, 3 } }, -- Antorus: Forbidden Descent
-  [1612] = { total=3, base=7, parent=1642, altid=nil, remap={ 1, 2, 3 } }, -- Antorus: Hope's End
-  [1613] = { total=2, base=10, parent=1642, altid=nil, remap={ 1, 2 } }, -- Antorus: Seat of the Pantheon
+  [1610] = { total=3, base=1,  parent=1642, altid=1916, remap={ 1, 2, 3 } }, -- Antorus1: Light's Breach
+  [1611] = { total=3, base=4,  parent=1642, altid=1915, remap={ 1, 2, 3 } }, -- Antorus2: Forbidden Descent
+  [1612] = { total=3, base=7,  parent=1642, altid=1914, remap={ 1, 2, 3 } }, -- Antorus3: Hope's End
+  [1613] = { total=2, base=10, parent=1642, altid=1913, remap={ 1, 2 } }, -- Antorus4: Seat of the Pantheon
 
   -- Battle for Azeroth
-  [1731] = { total=3, base=1, parent=1889, altid=nil, remap={ 1, 2, 3 } }, -- Uldir: Halls of Containment
-  [1732] = { total=3, base=4, parent=1889, altid=nil, remap={ 1, 2, 3 } }, -- Uldir: Crimson Descent
-  [1733] = { total=2, base=7, parent=1889, altid=nil, remap={ 1, 2 } },  -- Uldir: Heart of Corruption
+  [1731] = { total=3, base=1,  parent=1889, remap={ 1, 2, 3 } }, -- Uldir1: Halls of Containment
+  [1732] = { total=3, base=4,  parent=1889, remap={ 1, 2, 3 } }, -- Uldir2: Crimson Descent
+  [1733] = { total=2, base=7,  parent=1889, remap={ 1, 2 } },  -- Uldir3: Heart of Corruption
 
-  [1945] = { total=3, base=1, parent=1944, altid=nil, remap={ 1, 2, 3 } }, -- BoD: Siege of Dazar'alor (Alliance)
-  [1946] = { total=3, base=4, parent=1944, altid=nil, remap={ 1, 2, 3 } }, -- BoD: Empire's Fall (Alliance)
-  [1947] = { total=3, base=7, parent=1944, altid=nil, remap={ 1, 2, 3 } }, -- BoD: Might of the Alliance (Alliance)
+  [1945] = { total=3, base=1,  parent=1944, remap={ 1, 2, 3 } }, -- BoD1: Siege of Dazar'alor (Alliance)
+  [1946] = { total=3, base=4,  parent=1944, remap={ 1, 2, 3 } }, -- BoD2: Empire's Fall (Alliance)
+  [1947] = { total=3, base=7,  parent=1944, remap={ 1, 2, 3 } }, -- BoD3: Might of the Alliance (Alliance)
 
-  [1948] = { total=3, base=1, parent=1944, altid=nil, remap={ 1, 2, 3 } }, -- BoD: Defense of Dazar'alor (Horde)
-  [1949] = { total=3, base=4, parent=1944, altid=nil, remap={ 1, 2, 3 } }, -- BoD: Death's Bargain (Horde)
-  [1950] = { total=3, base=7, parent=1944, altid=nil, remap={ 1, 2, 3 } }, -- BoD: Victory or Death (Horde)
+  [1948] = { total=3, base=1,  parent=1944, remap={ 1, 2, 3 } }, -- BoD1: Defense of Dazar'alor (Horde)
+  [1949] = { total=3, base=4,  parent=1944, remap={ 1, 2, 3 } }, -- BoD2: Death's Bargain (Horde)
+  [1950] = { total=3, base=7,  parent=1944, remap={ 1, 2, 3 } }, -- BoD3: Victory or Death (Horde)
 
-  [1951] = { total=2, base=1, parent=1954, altid=nil, remap={ 1, 2 } }, -- Crucible of Storms
+  [1951] = { total=2, base=1,  parent=1954}, -- Crucible of Storms
 }
 
-local tmp = {}
-for id, info in pairs(addon.LFRInstances) do
-  tmp[id] = info
+local tbl = {}
+for id, info in pairs(LFRInstances) do
+  tbl[id] = info
   if info.altid then
-    tmp[info.altid] = info
+    tbl[info.altid] = info
   end
 end
-addon.LFRInstances = tmp
+addon.LFRInstances = tbl

--- a/SavedInstances/LFR.lua
+++ b/SavedInstances/LFR.lua
@@ -1,6 +1,8 @@
 local addonName, addon = ...
 local LFRModule = LibStub("AceAddon-3.0"):GetAddon(addonName):NewModule("LFR")
 
+local locFaction = UnitFactionGroup("player")
+
 local LFRInstances = {
   -- index is the id found in LFGDungeons.dbc or using the command below.
   -- /script local id,name; for i=1,GetNumRFDungeons() do id,name = GetRFDungeonInfo(i);print(i..". "..name.." ("..id..")");end
@@ -9,6 +11,8 @@ local LFRInstances = {
   -- /run for i, v in ipairs(GetLFRChoiceOrder()) do print(i, v, GetLFGDungeonInfo(v)) end
   -- altid is for alternate LFRID for higher level toons, use the command below
   -- /run for i = 1, 1951 do local _, _, _, _, maxLvl = GetLFGDungeonInfo(i) if maxLvl == 255 then print(i, GetLFGDungeonInfo(i)) end end
+  -- remap is the boss index different from increasing normally for current character
+  -- origin is the remap of character that runs the LFR
 
   -- Cataclysm
   [416] = { total=4, base=1,  parent=448, altid=843 }, -- DS1: The Siege of Wyrmrest Temple
@@ -76,19 +80,28 @@ local LFRInstances = {
   [1732] = { total=3, base=4,  parent=1889, remap={ 1, 2, 3 } }, -- Uldir2: Crimson Descent
   [1733] = { total=2, base=7,  parent=1889, remap={ 1, 2 } },  -- Uldir3: Heart of Corruption
 
-  [1945] = { total=3, base=1,  parent=1944, remap={ 1, 2, 3 } }, -- BoD1: Siege of Dazar'alor (Alliance)
-  [1946] = { total=3, base=4,  parent=1944, remap={ 1, 2, 3 } }, -- BoD2: Empire's Fall (Alliance)
-  [1947] = { total=3, base=7,  parent=1944, remap={ 1, 2, 3 } }, -- BoD3: Might of the Alliance (Alliance)
+  [1945] = { total=3, base=1,  parent=1944, remap={ 1, 2, 3 }, faction="Alliance" }, -- BoD1: Siege of Dazar'alor (Alliance)
+  [1946] = { total=3, base=4,  parent=1944, remap={ 1, 2, 3 }, faction="Alliance" }, -- BoD2: Empire's Fall (Alliance)
+  [1947] = { total=3, base=7,  parent=1944, remap={ 1, 2, 3 }, faction="Alliance" }, -- BoD3: Might of the Alliance (Alliance)
 
-  [1948] = { total=3, base=1,  parent=1944, remap={ 1, 2, 3 } }, -- BoD1: Defense of Dazar'alor (Horde)
-  [1949] = { total=3, base=4,  parent=1944, remap={ 1, 2, 3 } }, -- BoD2: Death's Bargain (Horde)
-  [1950] = { total=3, base=7,  parent=1944, remap={ 1, 2, 3 } }, -- BoD3: Victory or Death (Horde)
+  [1948] = { total=3, base=1,  parent=1944, remap={ 1, 2, 3 }, faction="Horde" }, -- BoD1: Defense of Dazar'alor (Horde)
+  [1949] = { total=3, base=4,  parent=1944, remap={ 1, 2, 3 }, faction="Horde" }, -- BoD2: Death's Bargain (Horde)
+  [1950] = { total=3, base=7,  parent=1944, remap={ 1, 2, 3 }, faction="Horde" }, -- BoD3: Victory or Death (Horde)
 
-  [1951] = { total=2, base=1,  parent=1954}, -- Crucible of Storms
+  [1951] = { total=2, base=1,  parent=1954, remap={ 1, 2 } }, -- Crucible of Storms
 }
 
 local tbl = {}
 for id, info in pairs(LFRInstances) do
+  if info.faction and locFaction ~= info.faction then
+    info.origin = info.remap
+    info.remap = nil
+    -- Battle of Dazar'alor
+    if id == 1945 or id == 1948 then
+      info.remap = {1, 3, 2}
+    end
+  end
+
   tbl[id] = info
   if info.altid then
     tbl[info.altid] = info


### PR DESCRIPTION
This PR focuses on LFR issues, including old LFRs and BoD LFR.

- [x] Fix old LFRs bosses information (fixes #113 , fixes #151 , fixes #217 )
- [x] Fix BoD LFR DifficultyString and tooltip

### Old LFRs
Blizzard allows high level character to enter previous LFR queue, but actually it is a different queue from original one. For example, Tormented Guardians of The Emerald Nightmare (Wing 2), the one entered by level 110 character has dungeonID `1288`, and the one entered by level 111 or higher has dungeonID `1927`, but they have the same name.

#### `GetLFGDungeonEncounterInfo`
`GetLFGDungeonEncounterInfo` does not return same result when it is called from all character. If a LFR queue which is not available by current character is provided, the boss index is of entire raid. In compare, if available one is provided, the index is of that wing. For example, if you run `GetLFGDungeonEncounterInfo(1288, 1)` on a 120 character, you will get the infomation of the first boss of entire raid, _Nythendra_, when running `GetLFGDungeonEncounterInfo(1927, 1)` brings the first boss of this wing, _Ursoc_. `1288` is the 110 LFR raid and `1927` is the same wing of it but is provided to lvl 111+ character.

### BoD LFRs
All 6 LFR wings shares the same parent, so Horde LFR wings reindex the same name after Alliance ones processed. So it makes only Horde LFR was tracked while only blank line was shown on Alliance character. But there are some problem of `GetLFGDungeonEncounterInfo`. Because one cannot join other faction's queue, so it makes `remap` of LFR to be different. So, there are some workaround on this, which prividing faction-depended `remap` and the origin one.