### PR TITLE
Several Updates

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -310,6 +310,7 @@ globals = {
 	"C_AuthChallenge.OnTabPressed",
 	"C_AuthChallenge.SetFrame",
 	"C_AuthChallenge.Submit",
+	"C_AzeriteItem",
 	"C_BlackMarket",
 	"C_BlackMarket.Close",
 	"C_BlackMarket.GetHotItem",

--- a/SavedInstances/Emissary.lua
+++ b/SavedInstances/Emissary.lua
@@ -40,6 +40,7 @@ function EmissaryModule:OnEnable()
 end
 
 function EmissaryModule:RefreshDailyWorldQuestInfo()
+  if addon.db.DailyResetTime < time() then return end -- daliy reset not run yet
   local t = addon.db.Toons[thisToon]
   if not t.Emissary then t.Emissary = {} end
   local expansionLevel, tbl
@@ -78,7 +79,6 @@ function EmissaryModule:RefreshDailyWorldQuestInfo()
           currExpansion[day].questNeed = questNeed
           currExpansion[day].expiredTime = timeleft * 60 + time()
           local tbl = t.Emissary[expansionLevel].days[day] or {}
-          tbl.expiredTime = timeleft * 60 + time()
           tbl.isComplete = false
           tbl.isFinish = isFinish
           tbl.questDone = questDone

--- a/SavedInstances/Emissary.lua
+++ b/SavedInstances/Emissary.lua
@@ -77,7 +77,7 @@ function EmissaryModule:RefreshDailyWorldQuestInfo()
           end
           currExpansion[day].questNeed = questNeed
           currExpansion[day].expiredTime = timeleft * 60 + time()
-          local tbl = t.Emissary[expansionLevel].days[day]
+          local tbl = t.Emissary[expansionLevel].days[day] or {}
           tbl.expiredTime = timeleft * 60 + time()
           tbl.isComplete = false
           tbl.isFinish = isFinish

--- a/SavedInstances/LFR.lua
+++ b/SavedInstances/LFR.lua
@@ -1,6 +1,7 @@
 local addonName, addon = ...
 local LFRModule = LibStub("AceAddon-3.0"):GetAddon(addonName):NewModule("LFR")
 
+local locLevel = UnitLevel("player")
 local locFaction = UnitFactionGroup("player")
 
 local LFRInstances = {
@@ -15,89 +16,98 @@ local LFRInstances = {
   -- origin is the remap of character that runs the LFR
 
   -- Cataclysm
-  [416] = { total=4, base=1,  parent=448, altid=843 }, -- DS1: The Siege of Wyrmrest Temple
-  [417] = { total=4, base=5,  parent=448, altid=844 }, -- DS2: Fall of Deathwing
+  [416] = { total=4, base=1,  parent=448, minLvl=86,  altid=843 }, -- DS1: The Siege of Wyrmrest Temple
+  [417] = { total=4, base=5,  parent=448, minLvl=86,  altid=844 }, -- DS2: Fall of Deathwing
 
   -- Mist of Pandaria
-  [527] = { total=3, base=1,  parent=532, altid=830, remap={ 1, 2, 3 } }, -- MSV1: Guardians of Mogu'shan
-  [528] = { total=3, base=4,  parent=532, altid=831, remap={ 1, 2, 3 } }, -- MSV2: The Vault of Mysteries
+  [527] = { total=3, base=1,  parent=532, minLvl=91,  altid=830, remap={ 1, 2, 3 } }, -- MSV1: Guardians of Mogu'shan
+  [528] = { total=3, base=4,  parent=532, minLvl=91,  altid=831, remap={ 1, 2, 3 } }, -- MSV2: The Vault of Mysteries
 
-  [529] = { total=3, base=1,  parent=534, altid=832, remap={ 1, 2, 3 } }, -- HoF1: The Dread Approach
-  [530] = { total=3, base=4,  parent=534, altid=833, remap={ 1, 2, 3 } }, -- HoF2: Nightmare of Shek'zeer
+  [529] = { total=3, base=1,  parent=534, minLvl=91,  altid=832, remap={ 1, 2, 3 } }, -- HoF1: The Dread Approach
+  [530] = { total=3, base=4,  parent=534, minLvl=91,  altid=833, remap={ 1, 2, 3 } }, -- HoF2: Nightmare of Shek'zeer
 
-  [526] = { total=4, base=1,  parent=536, altid=834 }, -- TeS1: Terrace of Endless Spring
+  [526] = { total=4, base=1,  parent=536, minLvl=91,  altid=834 }, -- TeS1: Terrace of Endless Spring
 
-  [610] = { total=3, base=1,  parent=634, altid=835, remap={ 1, 2, 3 } }, -- ToT1: Last Stand of the Zandalari
-  [611] = { total=3, base=4,  parent=634, altid=836, remap={ 1, 2, 3 } }, -- ToT2: Forgotten Depths
-  [612] = { total=3, base=7,  parent=634, altid=837, remap={ 1, 2, 3 } }, -- ToT3: Halls of Flesh-Shaping
-  [613] = { total=3, base=10, parent=634, altid=838, remap={ 1, 2, 3 } }, -- ToT4: Pinnacle of Storms
+  [610] = { total=3, base=1,  parent=634, minLvl=91,  altid=835, remap={ 1, 2, 3 } }, -- ToT1: Last Stand of the Zandalari
+  [611] = { total=3, base=4,  parent=634, minLvl=91,  altid=836, remap={ 1, 2, 3 } }, -- ToT2: Forgotten Depths
+  [612] = { total=3, base=7,  parent=634, minLvl=91,  altid=837, remap={ 1, 2, 3 } }, -- ToT3: Halls of Flesh-Shaping
+  [613] = { total=3, base=10, parent=634, minLvl=91,  altid=838, remap={ 1, 2, 3 } }, -- ToT4: Pinnacle of Storms
 
-  [716] = { total=4, base=1,  parent=766, altid=839, remap={ 1, 2, 3, 4 } }, -- SoO1: Vale of Eternal Sorrows
-  [717] = { total=4, base=5,  parent=766, altid=840, remap={ 1, 2, 3, 4 } }, -- SoO2: Gates of Retribution
-  [724] = { total=3, base=9,  parent=766, altid=841, remap={ 1, 2, 3 } }, -- SoO3: The Underhold
-  [725] = { total=3, base=12, parent=766, altid=842, remap={ 1, 2, 3 } }, -- SoO4: Downfall
+  [716] = { total=4, base=1,  parent=766, minLvl=91,  altid=839, remap={ 1, 2, 3, 4 } }, -- SoO1: Vale of Eternal Sorrows
+  [717] = { total=4, base=5,  parent=766, minLvl=91,  altid=840, remap={ 1, 2, 3, 4 } }, -- SoO2: Gates of Retribution
+  [724] = { total=3, base=9,  parent=766, minLvl=91,  altid=841, remap={ 1, 2, 3 } }, -- SoO3: The Underhold
+  [725] = { total=3, base=12, parent=766, minLvl=91,  altid=842, remap={ 1, 2, 3 } }, -- SoO4: Downfall
 
   -- Warlords of Draenor
-  [849] = { total=3, base=1,  parent=897, altid=1363, remap={ 1, 2, 3 } }, -- Highmaul1: Walled City
-  [850] = { total=3, base=4,  parent=897, altid=1364, remap={ 1, 2, 3 } }, -- Highmaul2: Arcane Sanctum
-  [851] = { total=1, base=7,  parent=897, altid=1365, remap={ 1 } }, -- Highmaul3: Imperator's Rise
+  [849] = { total=3, base=1,  parent=897, minLvl=101, altid=1363, remap={ 1, 2, 3 } }, -- Highmaul1: Walled City
+  [850] = { total=3, base=4,  parent=897, minLvl=101, altid=1364, remap={ 1, 2, 3 } }, -- Highmaul2: Arcane Sanctum
+  [851] = { total=1, base=7,  parent=897, minLvl=101, altid=1365, remap={ 1 } }, -- Highmaul3: Imperator's Rise
 
-  [847] = { total=3, base=1,  parent=900, altid=1361, remap={ 1, 2, 3 } }, -- BRF1: Slagworks
-  [846] = { total=3, base=4,  parent=900, altid=1360, remap={ 1, 2, 3 } }, -- BRF2: The Black Forge
-  [848] = { total=3, base=7,  parent=900, altid=1362, remap={ 1, 2, 3 } }, -- BRF3: Iron Assembly
-  [823] = { total=1, base=10, parent=900, altid=1359, remap={ 1 } }, -- BRF4: Blackhand's Crucible
+  [847] = { total=3, base=1,  parent=900, minLvl=101, altid=1361, remap={ 1, 2, 3 } }, -- BRF1: Slagworks
+  [846] = { total=3, base=4,  parent=900, minLvl=101, altid=1360, remap={ 1, 2, 3 } }, -- BRF2: The Black Forge
+  [848] = { total=3, base=7,  parent=900, minLvl=101, altid=1362, remap={ 1, 2, 3 } }, -- BRF3: Iron Assembly
+  [823] = { total=1, base=10, parent=900, minLvl=101, altid=1359, remap={ 1 } }, -- BRF4: Blackhand's Crucible
 
-  [982] = { total=3, base=1,  parent=989, altid=1366, remap={ 1, 2, 3 } }, -- Hellfire1: Hellbreach
-  [983] = { total=3, base=4,  parent=989, altid=1367, remap={ 1, 2, 3 } }, -- Hellfire2: Halls of Blood
-  [984] = { total=3, base=7,  parent=989, altid=1368, remap={ 1, 2, 3 } }, -- Hellfire3: Bastion of Shadows
-  [985] = { total=3, base=10, parent=989, altid=1369, remap={ 1, 2, 3 } }, -- Hellfire4: Destructor's Rise
-  [986] = { total=1, base=13, parent=989, altid=1370, remap={ 1 } }, -- Hellfire5: The Black Gate
+  [982] = { total=3, base=1,  parent=989, minLvl=101, altid=1366, remap={ 1, 2, 3 } }, -- Hellfire1: Hellbreach
+  [983] = { total=3, base=4,  parent=989, minLvl=101, altid=1367, remap={ 1, 2, 3 } }, -- Hellfire2: Halls of Blood
+  [984] = { total=3, base=7,  parent=989, minLvl=101, altid=1368, remap={ 1, 2, 3 } }, -- Hellfire3: Bastion of Shadows
+  [985] = { total=3, base=10, parent=989, minLvl=101, altid=1369, remap={ 1, 2, 3 } }, -- Hellfire4: Destructor's Rise
+  [986] = { total=1, base=13, parent=989, minLvl=101, altid=1370, remap={ 1 } }, -- Hellfire5: The Black Gate
 
   -- Legion
-  [1287] = { total=3, base=1,  parent=1350, altid=1912, remap={ 1, 2, 3 } }, -- EN1: Darkbough
-  [1288] = { total=3, base=4,  parent=1350, altid=1927, remap={ 1, 2, 3 } }, -- EN2: Tormented Guardians
-  [1289] = { total=1, base=7,  parent=1350, altid=1926, remap={ 1 } },       -- EN3: Rift of Aln
+  [1287] = { total=3, base=1,  parent=1350, minLvl=111, altid=1912, remap={ 1, 2, 3 } }, -- EN1: Darkbough
+  [1288] = { total=3, base=4,  parent=1350, minLvl=111, altid=1927, remap={ 1, 2, 3 } }, -- EN2: Tormented Guardians
+  [1289] = { total=1, base=7,  parent=1350, minLvl=111, altid=1926, remap={ 1 } },       -- EN3: Rift of Aln
 
-  [1290] = { total=3, base=1,  parent=1353, altid=1925, remap={ 1, 2, 3 } }, -- NH1: Arcing Aqueducts
-  [1291] = { total=3, base=4,  parent=1353, altid=1924, remap={ 1, 2, 3 } }, -- NH2: Royal Athenaeum
-  [1292] = { total=3, base=7,  parent=1353, altid=1923, remap={ 1, 2, 3 } }, -- NH3: Nightspire
-  [1293] = { total=1, base=10, parent=1353, altid=1922, remap={ 1 } }, -- NH4: Betrayer's Rise
+  [1290] = { total=3, base=1,  parent=1353, minLvl=111, altid=1925, remap={ 1, 2, 3 } }, -- NH1: Arcing Aqueducts
+  [1291] = { total=3, base=4,  parent=1353, minLvl=111, altid=1924, remap={ 1, 2, 3 } }, -- NH2: Royal Athenaeum
+  [1292] = { total=3, base=7,  parent=1353, minLvl=111, altid=1923, remap={ 1, 2, 3 } }, -- NH3: Nightspire
+  [1293] = { total=1, base=10, parent=1353, minLvl=111, altid=1922, remap={ 1 } }, -- NH4: Betrayer's Rise
 
-  [1411] = { total=3, base=1,  parent=1439, altid=1921 }, -- ToV
+  [1411] = { total=3, base=1,  parent=1439, minLvl=111, altid=1921 }, -- ToV
 
-  [1494] = { total=3, base=1,  parent=1527, altid=1920, remap={ 1, 2, 3 } }, -- ToS1: The Gates of Hell
-  [1495] = { total=3, base=4,  parent=1527, altid=1919, remap={ 1, 2, 3 } }, -- ToS2: Wailing Halls
-  [1496] = { total=2, base=7,  parent=1527, altid=1918, remap={ 1, 2 } }, -- ToS3: Chamber of the Avatar
-  [1497] = { total=1, base=9,  parent=1527, altid=1917, remap={ 1 } }, -- ToS4: Deceiver's Fall
+  [1494] = { total=3, base=1,  parent=1527, minLvl=111, altid=1920, remap={ 1, 2, 3 } }, -- ToS1: The Gates of Hell
+  [1495] = { total=3, base=4,  parent=1527, minLvl=111, altid=1919, remap={ 1, 2, 3 } }, -- ToS2: Wailing Halls
+  [1496] = { total=2, base=7,  parent=1527, minLvl=111, altid=1918, remap={ 1, 2 } }, -- ToS3: Chamber of the Avatar
+  [1497] = { total=1, base=9,  parent=1527, minLvl=111, altid=1917, remap={ 1 } }, -- ToS4: Deceiver's Fall
 
-  [1610] = { total=3, base=1,  parent=1642, altid=1916, remap={ 1, 2, 3 } }, -- Antorus1: Light's Breach
-  [1611] = { total=3, base=4,  parent=1642, altid=1915, remap={ 1, 2, 3 } }, -- Antorus2: Forbidden Descent
-  [1612] = { total=3, base=7,  parent=1642, altid=1914, remap={ 1, 2, 3 } }, -- Antorus3: Hope's End
-  [1613] = { total=2, base=10, parent=1642, altid=1913, remap={ 1, 2 } }, -- Antorus4: Seat of the Pantheon
+  [1610] = { total=3, base=1,  parent=1642, minLvl=111, altid=1916, remap={ 1, 2, 3 } }, -- Antorus1: Light's Breach
+  [1611] = { total=3, base=4,  parent=1642, minLvl=111, altid=1915, remap={ 1, 2, 3 } }, -- Antorus2: Forbidden Descent
+  [1612] = { total=3, base=7,  parent=1642, minLvl=111, altid=1914, remap={ 1, 2, 3 } }, -- Antorus3: Hope's End
+  [1613] = { total=2, base=10, parent=1642, minLvl=111, altid=1913, remap={ 1, 2 } }, -- Antorus4: Seat of the Pantheon
 
   -- Battle for Azeroth
-  [1731] = { total=3, base=1,  parent=1889, remap={ 1, 2, 3 } }, -- Uldir1: Halls of Containment
-  [1732] = { total=3, base=4,  parent=1889, remap={ 1, 2, 3 } }, -- Uldir2: Crimson Descent
-  [1733] = { total=2, base=7,  parent=1889, remap={ 1, 2 } },  -- Uldir3: Heart of Corruption
+  [1731] = { total=3, base=1,  parent=1889, minLvl=120, remap={ 1, 2, 3 } }, -- Uldir1: Halls of Containment
+  [1732] = { total=3, base=4,  parent=1889, minLvl=120, remap={ 1, 2, 3 } }, -- Uldir2: Crimson Descent
+  [1733] = { total=2, base=7,  parent=1889, minLvl=120, remap={ 1, 2 } },  -- Uldir3: Heart of Corruption
 
-  [1945] = { total=3, base=1,  parent=1944, remap={ 1, 2, 3 }, faction="Alliance" }, -- BoD1: Siege of Dazar'alor (Alliance)
-  [1946] = { total=3, base=4,  parent=1944, remap={ 1, 2, 3 }, faction="Alliance" }, -- BoD2: Empire's Fall (Alliance)
-  [1947] = { total=3, base=7,  parent=1944, remap={ 1, 2, 3 }, faction="Alliance" }, -- BoD3: Might of the Alliance (Alliance)
+  [1945] = { total=3, base=1,  parent=1944, minLvl=120, remap={ 1, 2, 3 }, faction="Alliance" }, -- BoD1: Siege of Dazar'alor (Alliance)
+  [1946] = { total=3, base=4,  parent=1944, minLvl=120, remap={ 1, 2, 3 }, faction="Alliance" }, -- BoD2: Empire's Fall (Alliance)
+  [1947] = { total=3, base=7,  parent=1944, minLvl=120, remap={ 1, 2, 3 }, faction="Alliance" }, -- BoD3: Might of the Alliance (Alliance)
 
-  [1948] = { total=3, base=1,  parent=1944, remap={ 1, 2, 3 }, faction="Horde" }, -- BoD1: Defense of Dazar'alor (Horde)
-  [1949] = { total=3, base=4,  parent=1944, remap={ 1, 2, 3 }, faction="Horde" }, -- BoD2: Death's Bargain (Horde)
-  [1950] = { total=3, base=7,  parent=1944, remap={ 1, 2, 3 }, faction="Horde" }, -- BoD3: Victory or Death (Horde)
+  [1948] = { total=3, base=1,  parent=1944, minLvl=120, remap={ 1, 2, 3 }, faction="Horde" }, -- BoD1: Defense of Dazar'alor (Horde)
+  [1949] = { total=3, base=4,  parent=1944, minLvl=120, remap={ 1, 2, 3 }, faction="Horde" }, -- BoD2: Death's Bargain (Horde)
+  [1950] = { total=3, base=7,  parent=1944, minLvl=120, remap={ 1, 2, 3 }, faction="Horde" }, -- BoD3: Victory or Death (Horde)
 
-  [1951] = { total=2, base=1,  parent=1954, remap={ 1, 2 } }, -- Crucible of Storms
+  [1951] = { total=2, base=1,  parent=1954, minLvl=120, remap={ 1, 2 } }, -- Crucible of Storms
 }
 
 local tbl = {}
 for id, info in pairs(LFRInstances) do
-  if info.faction and locFaction ~= info.faction then
+  if locLevel < info.minLvl or (info.faction and locFaction ~= info.faction) then
     info.origin = info.remap
     info.remap = nil
-    -- Battle of Dazar'alor
-    if id == 1945 or id == 1948 then
+    if id == 847 then -- BRF1: Slagworks
+      info.remap = { 1, 2, 7 }
+    elseif id == 846 then -- BRF2: The Black Forge
+      info.remap = { 3, 5, 8 }
+    elseif id == 848 then -- BRF3: Iron Assembly
+      info.remap = { 4, 6, 9 }
+    elseif id == 984 then -- Hellfire3: Bastion of Shadows
+      info.remap = { 7, 8,  11 }
+    elseif id == 985 then -- Hellfire4: Destructor's Rise
+      info.remap = { 9, 10, 12 }
+    elseif (id == 1945 or id == 1948) and (info.faction and locFaction ~= info.faction) then -- Battle of Dazar'alor: Wing 1
       info.remap = {1, 3, 2}
     end
   end

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -989,6 +989,7 @@ local _instance_exceptions = {
     25315, -- Kil'jaeden
   },
   [1347] = { total=8 }, -- Return to Karazhan
+  [1701] = { total=4 }, -- Siege of Boralus
 }
 
 function addon:instanceException(LFDID)

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -801,6 +801,7 @@ addon.transInstance = {
   [552] = 1011, -- Arcatraz: ticket 216 frFR
   [1516] = 1190, -- Arcway: ticket 227/233 ptBR
   [1651] = 1347, -- Return to Karazhan: ticket 237 (fake LFDID)
+  [545] = 185, -- The Steamvault: issue #143 esES
 }
 
 -- some instances (like sethekk halls) are named differently by GetSavedInstanceInfo() and LFGGetDungeonInfoByID()

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -9,9 +9,9 @@ addon.icon = addon.LDB and LibStub("LibDBIcon-1.0", true)
 
 local QTip = LibStub("LibQTip-1.0")
 local dataobject, db, config
-local maxdiff = 23 -- max number of instance difficulties
+local maxdiff = 33 -- max number of instance difficulties
 local maxcol = 4 -- max columns per player+instance
-local maxid = 2000 -- highest possible value for an instanceID, current max (Tomb of Sargeras) is 1676
+local maxid = 3000 -- highest possible value for an instanceID, current max (Battle of Dazar'alor) is 2070
 
 local table, math, bit, string, pairs, ipairs, unpack, strsplit, time, type, wipe, tonumber, select, strsub =
   table, math, bit, string, pairs, ipairs, unpack, strsplit, time, type, wipe, tonumber, select, strsub

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -285,6 +285,7 @@ addon.defaultDB = {
   -- Money: integer
   -- Zone: string
   -- Warmode: boolean
+  -- Artifact: string
 
   -- currency: key: currencyID  value:
   -- amount: integer
@@ -1637,6 +1638,12 @@ function addon:UpdateToonData()
     t.Race = lrace
   end
   t.Warmode = C_PvP.IsWarModeDesired()
+  local azeriteItemLocation = C_AzeriteItem.FindActiveAzeriteItem()
+  if azeriteItemLocation then
+    local xp, totalLevelXP = C_AzeriteItem.GetAzeriteItemXPInfo(azeriteItemLocation)
+    local currentLevel = C_AzeriteItem.GetPowerLevel(azeriteItemLocation)
+    t.Artifact = format("%d (%d%%)", currentLevel, xp / totalLevelXP  * 100)
+  end
 
   t.LastSeen = time()
 end
@@ -1776,6 +1783,9 @@ hoverTooltip.ShowToonTooltip = function (cell, arg, ...)
   indicatortip:SetCell(indicatortip:AddHeader(),1,ftex..ClassColorise(t.Class, toon))
   indicatortip:SetCell(1,2,ClassColorise(t.Class, LEVEL.." "..t.Level.." "..(t.LClass or "")))
   indicatortip:AddLine(STAT_AVERAGE_ITEM_LEVEL,("%d "):format(t.IL or 0)..STAT_AVERAGE_ITEM_LEVEL_EQUIPPED:format(t.ILe or 0))
+  if t.Artifact then
+    indicatortip:AddLine(ARTIFACT_POWER, t.Artifact)
+  end
   if t.RBGrating and t.RBGrating > 0 then
     indicatortip:AddLine(BATTLEGROUND_RATING, t.RBGrating)
   end

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -343,7 +343,6 @@ addon.defaultDB = {
   --       isComplete = isComplete,
   --       isFinish = isFinish,
   --       questDone = questDone,
-  --       expiredTime = expiredTime,
   --       questReward = {
   --         money = money,
   --         itemName = itemName,
@@ -1532,20 +1531,6 @@ function addon:UpdateToonData()
             ti.Quests[id] = nil
           end
         end
-        if ti.Emissary then
-          local expansionLevel, tbl
-          for expansionLevel, tbl in pairs(ti.Emissary) do
-            if tbl.unlocked then
-              tbl.days[1] = tbl.days[2]
-              tbl.days[2] = tbl.days[3]
-              tbl.days[3] = {
-                isComplete = false,
-                isFinish = false,
-                questDone = 0,
-              }
-            end
-          end
-        end
         ti.DailyResetTime = (ti.DailyResetTime and ti.DailyResetTime + 24*3600) or nextreset
       end
     end
@@ -1556,12 +1541,29 @@ function addon:UpdateToonData()
           db.Quests[id] = nil
         end
     end
+    -- Emissary Quest Reset
     if addon.db.Emissary and addon.db.Emissary.Expansion then
       local expansionLevel, tbl
       for expansionLevel, tbl in pairs(addon.db.Emissary.Expansion) do
-        tbl[1] = tbl[2]
-        tbl[2] = tbl[3]
-        tbl[3] = nil
+        while tbl[1] and tbl[1].expiredTime < time() do
+          tbl[1] = tbl[2]
+          tbl[2] = tbl[3]
+          tbl[3] = nil
+          for toon, ti in pairs(addon.db.Toons) do
+            if ti.Emissary then
+              local t = ti.Emissary[expansionLevel]
+              if t and t.unlocked then
+                t.days[1] = t.days[2]
+                t.days[2] = t.days[3]
+                t.days[3] = {
+                  isComplete = false,
+                  isFinish = false,
+                  questDone = 0,
+                }
+              end
+            end
+          end
+        end
       end
     end
     db.DailyResetTime = nextreset


### PR DESCRIPTION
#### Small Patches
* Set the number of total bosses in SoB 4 (#160 )
* Fix The Steamvault in esES
* Increase the max number of instance id and difficulty id
* Track Heart of Azeroth, and show it in ToonTooltip
* Newly added `origin` in LFR infomation can allow low level character to show LFR lockouts, so it is

#### Emissary Reset
Currently `RefreshDailyWorldQuestInfo` runs before `UpdateToonData`, so after daily reset, logging in a character which have done emissary quest previous day will pollute the name of previous emissary quest. Because it firstly refreshes emissary quest and places the name, and then daily refresh places the name the day before the correct day. This commit provides a way to block emissary quest refresh before daily refresh. So the way (from 0a1e3ba) to daily refresh emissary quest is avilable now.