### PR TITLE
Several Updates

### DIFF
--- a/SavedInstances/Paragon.lua
+++ b/SavedInstances/Paragon.lua
@@ -49,3 +49,5 @@ function P:UPDATE_FACTION()
     end
   end
 end
+
+hooksecurefunc("GetQuestReward", function() P:UPDATE_FACTION() end)

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -2024,6 +2024,20 @@ hoverTooltip.ShowEmissaryTooltip = function (cell, arg, ...)
   finishIndicator()
 end
 
+hoverTooltip.ShowParagonTooltip = function (cell, arg, ...)
+  local toon = arg
+  local t = addon.db.Toons[toon]
+  if not t or not t.Paragon then return end
+  openIndicator(2, "LEFT", "RIGHT")
+  indicatortip:AddHeader(ClassColorise(t.Class, toon), #t.Paragon)
+  for k, v in pairs(t.Paragon) do
+    local name = GetFactionInfoByID(v)
+    indicatortip:AddLine()
+    indicatortip:SetCell(k + 1, 1, name, "RIGHT", 2)
+  end
+  finishIndicator()
+end
+
 hoverTooltip.ShowBonusTooltip = function (cell, arg, ...)
   local toon = arg
   local parent
@@ -4091,10 +4105,12 @@ function core:ShowTooltip(anchorframe)
       end
       show = tooltip:AddLine(YELLOWFONT .. L["Paragon Chests"] .. FONTEND)
       for toon, t in cpairs(addon.db.Toons, true) do
-        local col = columns[toon..1]
-        tooltip:SetCell(show, col, t.Paragon and #t.Paragon or 0, "CENTER", maxcol)
-        tooltip:SetCellScript(show, col, "OnEnter", hoverTooltip.ShowParagonTooltip, toon)
-        tooltip:SetCellScript(show, col, "OnLeave", CloseTooltips)
+        if t.Paragon and #t.Paragon > 0 then
+          local col = columns[toon..1]
+          tooltip:SetCell(show, col, #t.Paragon, "CENTER", maxcol)
+          tooltip:SetCellScript(show, col, "OnEnter", hoverTooltip.ShowParagonTooltip, toon)
+          tooltip:SetCellScript(show, col, "OnLeave", CloseTooltips)
+        end
       end
     end
   end

--- a/SavedInstances/WorldBosses.lua
+++ b/SavedInstances/WorldBosses.lua
@@ -60,7 +60,8 @@ addon.WorldBosses = {
 
   -- bosses with no EJ entry (eid is a placeholder)
   [9001] = { quest=38276, name=GARRISON_LOCATION_TOOLTIP.." "..BOSS, expansion=5, level=100 },
-  [9002] = { quest=47461, name="Lord Kazzak", expansion=6, level=110},          -- Lord Kazzak (13th Anniversary)
-  [9003] = { quest=47462, name="Azuregos", expansion=6, level=110},             -- Azuregos (13th Anniversary)
-  [9004] = { quest=47463, name="Dragon of Nightmare", expansion=6, level=110},  -- Dragon of Nightmare (13th Anniversary)
+  -- Old Vanilla Bosses during Anniversary Event
+  [9002] = { quest=47461, name=L["Lord Kazzak"], expansion=7, level=120},          -- Lord Kazzak
+  [9003] = { quest=47462, name=L["Azuregos"], expansion=7, level=120},             -- Azuregos
+  [9004] = { quest=47463, name=L["Dragon of Nightmare"], expansion=7, level=120},  -- Dragon of Nightmare
 }

--- a/SavedInstances/config.lua
+++ b/SavedInstances/config.lua
@@ -457,7 +457,7 @@ function Config:BuildOptions()
           TrackParagon = {
             type = "toggle",
             order = 48,
-            name = L["Paragon Chest"],
+            name = L["Paragon Chests"],
           },
           BindHeader = {
             order = -0.6,


### PR DESCRIPTION
* Make Anniversary World Bosses' name able to locate
* Fix lua error and remove useless locate string of last update
* Add a missing detail tooltip function
* Update Paragon Chests Info when Completing Quest