### PR TITLE
Improve Module Quest and Progress

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -926,6 +926,7 @@ globals = {
 	"C_Questline",
 	"C_Questline.GetNumAvailableQuestlines",
 	"C_Questline.GetQuestlineInfoByIndex",
+	"C_QuestLog",
 	"C_RecruitAFriend",
 	"C_RecruitAFriend.CheckEmailEnabled",
 	"C_RecruitAFriend.GetRecruitInfo",

--- a/SavedInstances/Quests.lua
+++ b/SavedInstances/Quests.lua
@@ -154,6 +154,7 @@ local QuestExceptions = {
   [53033] = "Weekly", -- A Frozen Path Through Time - WLK Timewalking
   [53034] = "Weekly", -- A Shattered Path Through Time - CTM Timewalking
   [53035] = "Weekly", -- A Shattered Path Through Time - MOP Timewalking
+  [54995] = "Weekly", -- A Savage Path Through Time - WOD Timewalking
   [53036] = "Weekly", -- A Call to Battle - Battlegrounds
   [53037] = "Weekly", -- Emissary of War - Mythic Dungeons
   [53038] = "AccountWeekly", -- The Very Best - PvP Pet Battles
@@ -185,6 +186,8 @@ local TimewalkingItemQuest = {
   [40786] = 1304688, -- The Smoldering Ember - CTM Timewalking - Horde
   [40787] = 1304688, -- The Smoldering Ember - CTM Timewalking - Alliance
   [45563] = 1530590, -- The Shrouded Coin - MOP Timewalking
+  [55498] = 1129683, -- The Shimmering Crystal - WOD Timewalking - Alliance
+  [55499] = 1129683, -- The Shimmering Crystal - WOD Timewalking - Horde
 }
 for questID, tbl in pairs(TimewalkingItemQuest) do
   QuestExceptions[questID] = "Weekly"

--- a/SavedInstances/Quests.lua
+++ b/SavedInstances/Quests.lua
@@ -125,6 +125,13 @@ local QuestExceptions = {
   [33338] = "Weekly",  -- Empowering the Hourglass
   [33334] = "Weekly",  -- Strong Enough to Survive
 
+  -- Draenor Pet Battle
+  [37644] = "AccountDaily", -- Mastering the Menagerie (Alliance)
+  [37645] = "AccountDaily", -- Mastering the Menagerie (Horde)
+  [38299] = "AccountDaily", -- Critters of Draenor (Alliance)
+  [38300] = "AccountDaily", -- Critters of Draenor (Horde)
+  [40329] = "AccountWeekly", -- Battle Pet Tamers: Warlords
+
   -- Pet Battle Dungeons
   [46292] = "AccountWeekly", -- Pet Battle Challenge Dungeon Deadmines
   [45539] = "AccountWeekly", -- Pet Battle Challenge Dungeon Wailing Caverns

--- a/SavedInstances/Quests.lua
+++ b/SavedInstances/Quests.lua
@@ -176,15 +176,15 @@ local QuestExceptions = {
 addon.QuestExceptions = QuestExceptions
 
 -- Timewalking Dungeon final boss drops
--- to find eventID, select the event in calendar and use the command below
--- /run local i = C_Calendar.GetEventIndex() local e = C_Calendar.GetDayEvent(i.offsetMonths, i.monthDay, i.eventIndex) print(e.eventID)
--- [questID] = eventID
+-- to find iconTexture, select the event in calendar and use the command below
+-- /run local i = C_Calendar.GetEventIndex() local e = C_Calendar.GetDayEvent(i.offsetMonths, i.monthDay, i.eventIndex) print(e.iconTexture)
+-- [questID] = iconTexture
 local TimewalkingItemQuest = {
-  [40168] = 623, -- The Swirling Vial - TBC Timewalking
-  [40173] = 617, -- The Unstable Prism - WLK Timewalking
-  [40786] = 629, -- The Smoldering Ember - CTM Timewalking - Horde
-  [40787] = 629, -- The Smoldering Ember - CTM Timewalking - Alliance
-  [45563] = 654, -- The Shrouded Coin - MOP Timewalking
+  [40168] = 1129674, -- The Swirling Vial - TBC Timewalking
+  [40173] = 1129686, -- The Unstable Prism - WLK Timewalking
+  [40786] = 1304688, -- The Smoldering Ember - CTM Timewalking - Horde
+  [40787] = 1304688, -- The Smoldering Ember - CTM Timewalking - Alliance
+  [45563] = 1530590, -- The Shrouded Coin - MOP Timewalking
 }
 for questID, tbl in pairs(TimewalkingItemQuest) do
   QuestExceptions[questID] = "Weekly"

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -355,6 +355,7 @@ addon.defaultDB = {
 
   -- Progress
   -- [index] = {
+  --   unlocked = (boolean), -- if player can complete this quest
   --   isComplete = isComplete,
   --   isFinish = isFinish,
   --   numFulfilled = numFulfilled,

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -84,7 +84,7 @@ for i = 0,10 do
   end
 end
 
--- eventInfo format: [eventID] = true
+-- eventInfo format: [iconTexture] = true
 local eventInfo = {}
 local tooltip, indicatortip = nil, nil
 addon.indicatortip = indicatortip
@@ -771,19 +771,19 @@ local function UpdateEventInfo()
   debug("numEvents: " .. numEvents)
   for i = 1, numEvents do
     local event = C_Calendar.GetDayEvent(monthOffset, day, i)
-    debug("eventID: " .. event.eventID)
+    debug("iconTexture: " .. event.iconTexture)
     if event.sequenceType == "START" then
       local hour, minute = event.startTime.hour, event.startTime.minute
       if hour < current.hour or (hour == current.hour and minute < current.minute) then
-        eventInfo[event.eventID] = true
+        eventInfo[event.iconTexture] = true
       end
     elseif event.sequenceType == "END" then
       local hour, minute = event.startTime.hour, event.startTime.minute
       if hour > current.hour or (hour == current.hour and minute > current.minute) then
-        eventInfo[event.eventID] = true
+        eventInfo[event.iconTexture] = true
       end
     else -- "ONGOING"
-      eventInfo[event.eventID] = true
+      eventInfo[event.iconTexture] = true
     end
   end
 end


### PR DESCRIPTION
* Use event iconTexture to track events, eventID depends on realm, no idea why
* Track WoD Timewalking quest, questID from wowhead's PTR database
* Don't show progress if quest is not unlocked or not on the quest
* Track Draenor Pet Battle Quest (closes #266 )