### PR TITLE
Several Updates

### DIFF
--- a/SavedInstances/MythicPlus.lua
+++ b/SavedInstances/MythicPlus.lua
@@ -18,15 +18,15 @@ local GetItemQualityColor = GetItemQualityColor
 
 local KeystoneAbbrev = {
   [244] = L["AD"],
-  [245] = L["Free"],
+  [245] = L["FH"],
   [246] = L["TD"],
-  [247] = L["MOTHER"],
+  [247] = L["ML"],
   [248] = L["WM"],
   [249] = L["KR"],
-  [250] = L["ToS"],
-  [251] = L["Under"],
-  [252] = L["SotS"],
-  [353] = L["SoB"],
+  [250] = L["TOS"],
+  [251] = L["UNDR"],
+  [252] = L["SOTS"],
+  [353] = L["SIEGE"],
 }
 addon.KeystoneAbbrev = KeystoneAbbrev
 

--- a/SavedInstances/Quests.lua
+++ b/SavedInstances/Quests.lua
@@ -184,17 +184,18 @@ local QuestExceptions = {
 addon.QuestExceptions = QuestExceptions
 
 -- Timewalking Dungeon final boss drops
--- to find iconTexture, select the event in calendar and use the command below
--- /run local i = C_Calendar.GetEventIndex() local e = C_Calendar.GetDayEvent(i.offsetMonths, i.monthDay, i.eventIndex) print(e.iconTexture)
--- [questID] = iconTexture
+-- to find iconTexture, select the day in calendar and use the command below
+-- please note: event might have THREE different iconTexutre when START, ONGOING, END
+-- /run local F,O,I,m,d,e=CalendarFrame,C_Calendar I=O.GetMonthInfo()m=-12*(I.year-F.selectedYear)+F.selectedMonth-I.month d=F.selectedDay for i=1,O.GetNumDayEvents(m,d)do e=O.GetDayEvent(m,d,i)print(e.title,e.iconTexture)end
+-- [questID] = {iconTextures}
 local TimewalkingItemQuest = {
-  [40168] = 1129674, -- The Swirling Vial - TBC Timewalking
-  [40173] = 1129686, -- The Unstable Prism - WLK Timewalking
-  [40786] = 1304688, -- The Smoldering Ember - CTM Timewalking - Horde
-  [40787] = 1304688, -- The Smoldering Ember - CTM Timewalking - Alliance
-  [45563] = 1530590, -- The Shrouded Coin - MOP Timewalking
-  [55498] = 1129683, -- The Shimmering Crystal - WOD Timewalking - Alliance
-  [55499] = 1129683, -- The Shimmering Crystal - WOD Timewalking - Horde
+  [40168] = {1129672, 1129673, 1129674}, -- The Swirling Vial - TBC Timewalking
+  [40173] = {1129684, 1129685, 1129686}, -- The Unstable Prism - WLK Timewalking
+  [40786] = {1304686, 1304687, 1304688}, -- The Smoldering Ember - CTM Timewalking - Horde
+  [40787] = {1304686, 1304687, 1304688}, -- The Smoldering Ember - CTM Timewalking - Alliance
+  [45563] = {1530588, 1530589, 1530590}, -- The Shrouded Coin - MOP Timewalking
+  [55498] = {1129681, 1129682, 1129683}, -- The Shimmering Crystal - WOD Timewalking - Alliance
+  [55499] = {1129681, 1129682, 1129683}, -- The Shimmering Crystal - WOD Timewalking - Horde
 }
 for questID, tbl in pairs(TimewalkingItemQuest) do
   QuestExceptions[questID] = "Weekly"

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -736,6 +736,20 @@ do
   end
 end
 
+function addon:QuestIgnored(questID)
+  if (TimewalkingItemQuest[questID]) then
+    -- Timewalking Item Quests
+    for _, iconTexture in ipairs(TimewalkingItemQuest[questID]) do
+      if eventInfo[iconTexture] then
+        -- Timewalking Weedend Event ONGOING
+        return
+      end
+    end
+    return true
+  end
+  return
+end
+
 function addon:QuestCount(toonname)
   local t
   if toonname then
@@ -748,9 +762,7 @@ function addon:QuestCount(toonname)
   -- ticket 96: GetDailyQuestsCompleted() is unreliable, the response is laggy and it fails to count some quests
   local id, info
   for id, info in pairs(t.Quests) do
-    if (TimewalkingItemQuest[id] and (not eventInfo[TimewalkingItemQuest[id]])) then
-      -- Timewalking Item Quests only show during Timewalking Weeks
-    else
+    if not self:QuestIgnored(id) then
       if info.isDaily then
         dailycount = dailycount + 1
       else
@@ -1875,9 +1887,7 @@ hoverTooltip.ShowQuestTooltip = function (cell, arg, ...)
   local zonename, id
   for id,qi in pairs(t.Quests) do
     if (not isDaily) == (not qi.isDaily) then
-      if (TimewalkingItemQuest[id] and (not eventInfo[TimewalkingItemQuest[id]])) then
-        -- Timewalking Item Quests only show during Timewalking Weeks
-      else
+      if not addon:QuestIgnored(id) then
         zonename = qi.Zone and qi.Zone.name or ""
         table.insert(ql,zonename.." # "..id)
       end

--- a/SavedInstances/Warfront.lua
+++ b/SavedInstances/Warfront.lua
@@ -163,3 +163,7 @@ function W:ShowTooltip(tooltip, columns, showall, preshow)
     end
   end
 end
+
+hooksecurefunc("GetQuestReward", function()
+  W:ScheduleTimer("UpdateQuest", 1)
+end)


### PR DESCRIPTION
* Use Mythic+ Keystone abbreviation from Raider.io
* Timewalking events have three different `iconTexture`s at START, ONGOING and END
* Hook `GetQuestReward` to update Warfront scenario