### PR TITLE
Fix progress reset

### DIFF
--- a/SavedInstances/Progress.lua
+++ b/SavedInstances/Progress.lua
@@ -134,17 +134,17 @@ function P:QUEST_LOG_UPDATE()
       if questID then
         -- no questID on Neutral Pandaren or first login
         local result = {}
+        local _, _, finished, numFulfilled, numRequired = GetQuestObjectiveInfo(questID, 1, false)
+        result.isFinish = finished
+        result.numFulfilled = numFulfilled
+        result.numRequired = numRequired
         if IsQuestFlaggedCompleted(questID) then
           result.unlocked = true
           result.isComplete = true
         else
           local isOnQuest = C_QuestLog_IsOnQuest(questID)
-          local _, _, finished, numFulfilled, numRequired = GetQuestObjectiveInfo(questID, 1, false)
           result.unlocked = isOnQuest
           result.isComplete = false
-          result.isFinish = finished
-          result.numFulfilled = numFulfilled
-          result.numRequired = numRequired
         end
         t.Progress[i] = result
       end


### PR DESCRIPTION
While adding an indication for PvP weekly chest ready to loot, I noticed the Progress module was not updating on resets at all before logging in on each character. This PR fixes that.