### PR TITLE
Add Related Item Count to Specific Currency

### DIFF
--- a/SavedInstances/Currency.lua
+++ b/SavedInstances/Currency.lua
@@ -1,21 +1,18 @@
 local _, addon = ...
-local CurrencyModule = addon.core:NewModule("Currency", "AceEvent-3.0", "AceTimer-3.0", "AceBucket-3.0")
+local CU = addon.core:NewModule("Currency", "AceEvent-3.0", "AceTimer-3.0", "AceBucket-3.0")
 local thisToon = UnitName("player") .. " - " .. GetRealmName()
 
-local SEASON_SCAN = CURRENCY_SEASON_TOTAL:gsub("%%%d*?([ds])","(%%%1*)")
+local seasonTotalPatten = gsub(CURRENCY_SEASON_TOTAL, "%%s%%s", "(.+)")
 
 -- Lua functions
-local wipe, ipairs, pairs = wipe, ipairs, pairs
+local ipairs, pairs, strfind, wipe = ipairs, pairs, strfind, wipe
 local _G = _G
 
 -- WoW API / Variables
 local GetCurrencyInfo = GetCurrencyInfo
+local GetItemCount = GetItemCount
 local GetMoney = GetMoney
 local IsQuestFlaggedCompleted = C_QuestLog and C_QuestLog.IsQuestFlaggedCompleted or IsQuestFlaggedCompleted
-
-function CurrencyModule:OnEnable()
-  self:RegisterBucketEvent("CURRENCY_DISPLAY_UPDATE", 0.25, function() addon:UpdateCurrency() end)
-end
 
 local currency = {
   81, -- Epicurean Award
@@ -72,53 +69,60 @@ local specialCurrency = {
   [1129] = { -- WoD - Seal of Tempered Fate
     weeklyMax = 3,
     earnByQuest = {
-      [36058] = true,  -- Seal of Dwarven Bunker
+      36058,  -- Seal of Dwarven Bunker
       -- Seal of Ashran quests
-      [36054] = true,
-      [37454] = true,
-      [37455] = true,
-      [36056] = true,
-      [37456] = true,
-      [37457] = true,
-      [36057] = true,
-      [37458] = true,
-      [37459] = true,
-      [36055] = true,
-      [37452] = true,
-      [37453] = true,
+      36054,
+      37454,
+      37455,
+      36056,
+      37456,
+      37457,
+      36057,
+      37458,
+      37459,
+      36055,
+      37452,
+      37453,
     },
   },
   [1273] = { -- LEG - Seal of Broken Fate
     weeklyMax = 3,
     earnByQuest = {
-      [43895] = true,
-      [43896] = true,
-      [43897] = true,
-      [43892] = true,
-      [43893] = true,
-      [43894] = true,
-      [43510] = true, -- Order Hall
-      [47851] = true, -- Mark of Honor x5
-      [47864] = true, -- Mark of Honor x10
-      [47865] = true, -- Mark of Honor x20
+      43895,
+      43896,
+      43897,
+      43892,
+      43893,
+      43894,
+      43510, -- Order Hall
+      47851, -- Mark of Honor x5
+      47864, -- Mark of Honor x10
+      47865, -- Mark of Honor x20
     },
   },
   [1580] = { -- BfA - Seal of Wartorn Fate
     weeklyMax = 2,
     earnByQuest = {
-      [52834] = true, -- Gold
-      [52838] = true, -- Piles of Gold
-      [52835] = true, -- Marks of Honor
-      [52839] = true, -- Additional Marks of Honor
-      [52837] = true, -- War Resources
-      [52840] = true, -- Stashed War Resources
+      52834, -- Gold
+      52838, -- Piles of Gold
+      52835, -- Marks of Honor
+      52839, -- Additional Marks of Honor
+      52837, -- War Resources
+      52840, -- Stashed War Resources
+    },
+  },
+  [1755] = { -- BfA - Coalescing Visions
+    relatedItem = {
+      id = 173363, -- Vessel of Horrific Visions
+      holdingMax = 5,
     },
   },
 }
+addon.specialCurrency = specialCurrency
 
 for _, tbl in pairs(specialCurrency) do
   if tbl.earnByQuest then
-    for questID in pairs(tbl.earnByQuest) do
+    for _, questID in ipairs(tbl.earnByQuest) do
       addon.QuestExceptions[questID] = "Regular" -- not show in Weekly Quest
     end
   end
@@ -129,14 +133,19 @@ local function GetSeasonCurrency(idx)
   addon.scantt:SetCurrencyByID(idx)
   local name = addon.scantt:GetName()
   for i = 1, addon.scantt:NumLines() do
-    local left = _G[name.."TextLeft"..i]
-    if left:GetText():find(SEASON_SCAN) then
-      return left:GetText()
+    local text = _G[name .. "TextLeft" .. i]:GetText()
+    if strfind(text, seasonTotalPatten) then
+      return text
     end
   end
 end
 
-function addon:UpdateCurrency()
+function CU:OnEnable()
+  self:RegisterBucketEvent("CURRENCY_DISPLAY_UPDATE", 0.25, "UpdateCurrency")
+  self:RegisterEvent("BAG_UPDATE", "UpdateCurrencyItem")
+end
+
+function CU:UpdateCurrency()
   if addon.logout then return end -- currency is unreliable during logout
   local t = addon.db.Toons[thisToon]
   t.Money = GetMoney()
@@ -154,11 +163,14 @@ function addon:UpdateCurrency()
         if tbl.weeklyMax then ci.weeklyMax = tbl.weeklyMax end
         if tbl.earnByQuest then
           ci.earnedThisWeek = 0
-          for questID in pairs(tbl.earnByQuest) do
+          for _, questID in ipairs(tbl.earnByQuest) do
             if IsQuestFlaggedCompleted(questID) then
               ci.earnedThisWeek = ci.earnedThisWeek + 1
             end
           end
+        end
+        if tbl.relatedItem then
+          ci.relatedItemCount = GetItemCount(tbl.relatedItem.id)
         end
       end
       ci.season = GetSeasonCurrency(idx)
@@ -166,6 +178,14 @@ function addon:UpdateCurrency()
       if ci.totalMax == 0 then ci.totalMax = nil end -- don't store useless info
       if ci.earnedThisWeek == 0 then ci.earnedThisWeek = nil end -- don't store useless info
       t.currency[idx] = ci
+    end
+  end
+end
+
+function CU:UpdateCurrencyItem()
+  for currencyID, tbl in pairs(specialCurrency) do
+    if tbl.relatedItem then
+      addon.db.Toons[thisToon].currency[currencyID].relatedItemCount = GetItemCount(tbl.relatedItem.id)
     end
   end
 end

--- a/SavedInstances/Currency.lua
+++ b/SavedInstances/Currency.lua
@@ -5,12 +5,11 @@ local thisToon = UnitName("player") .. " - " .. GetRealmName()
 local seasonTotalPatten = gsub(CURRENCY_SEASON_TOTAL, "%%s%%s", "(.+)")
 
 -- Lua functions
-local ipairs, pairs, strfind, wipe = ipairs, pairs, strfind, wipe
+local wipe, ipairs, pairs = wipe, ipairs, pairs
 local _G = _G
 
 -- WoW API / Variables
 local GetCurrencyInfo = GetCurrencyInfo
-local GetItemCount = GetItemCount
 local GetMoney = GetMoney
 local IsQuestFlaggedCompleted = C_QuestLog and C_QuestLog.IsQuestFlaggedCompleted or IsQuestFlaggedCompleted
 
@@ -183,8 +182,10 @@ function CU:UpdateCurrency()
 end
 
 function CU:UpdateCurrencyItem()
+  if not addon.db.Toons[thisToon].currency then return end
+
   for currencyID, tbl in pairs(specialCurrency) do
-    if tbl.relatedItem then
+    if tbl.relatedItem and addon.db.Toons[thisToon].currency[currencyID] then
       addon.db.Toons[thisToon].currency[currencyID].relatedItemCount = GetItemCount(tbl.relatedItem.id)
     end
   end

--- a/SavedInstances/Quests.lua
+++ b/SavedInstances/Quests.lua
@@ -139,8 +139,8 @@ local QuestExceptions = {
 
   -- BfA
   -- Island Expeditions (Moved to Progress.lua)
-  [53435] = "Regular", -- Azerite for the Horde
-  [53436] = "Regular", -- Azerite for the Alliance
+  [53435] = "Weekly", -- Azerite for the Horde
+  [53436] = "Weekly", -- Azerite for the Alliance
   -- Warfront (Moved to Warfront.lua)
   [53414] = "Regular", -- Stromgarde Alliance
   [53416] = "Regular", -- Stromgarde Horde

--- a/SavedInstances/Quests.lua
+++ b/SavedInstances/Quests.lua
@@ -201,6 +201,7 @@ local QuestExceptions = {
   [46292] = "AccountWeekly", -- Pet Battle Challenge: Deadmines
   [54186] = "AccountWeekly", -- Pet Battle Challenge: Gnomeregan
   [56492] = "AccountWeekly", -- Pet Battle Challenge: Stratholme
+  [58458] = "AccountWeekly", -- Pet Battle Challenge: Blackrock Depths
 
   -- Weekend Event
   [53030] = "Weekly", -- The World Awaits - World Quests

--- a/SavedInstances/Quests.lua
+++ b/SavedInstances/Quests.lua
@@ -169,14 +169,14 @@ local QuestExceptions = {
   [56116] = "Regular", -- Even More Recycling
   [56649] = "Weekly", -- Call to Arms: Mechagon (Alliance)
   [56650] = "Weekly", -- Call to Arms: Mechagon (Horde)
-    -- Assaults
+  -- Assaults
   [57157] = "Weekly", -- Assault: The Black Empire (Uldum)
   [56064] = "Weekly", -- Assault: The Black Empite (Vale of Eternal Blossoms)
-  [55350] = "Weekly", -- Assault: Amathet Advance (Umdum)
+  [55350] = "Weekly", -- Assault: Amathet Advance (Uldum)
   [57008] = "Weekly", -- Assault: The Warring Clans (Vale of Eternal Blossoms)
   [57728] = "Weekly", -- Assault: The Endless Swarm (Vale of Eternal Blossoms)
   [56308] = "Weekly", -- Assault: Aqir Unearthed (Uldum)
-  -- Lesser Visions
+  -- Lesser Visions of N'Zoth
   [58168] = "Daily", -- A Dark, Glaring Reality
   [58155] = "Daily", -- A Hand in the Dark
   [58151] = "Daily", -- Minions of N'Zoth

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -297,6 +297,7 @@ addon.defaultDB = {
   -- weeklyMax: integer
   -- totalMax: integer
   -- season: integer
+  -- relatedItemCount: integer
 
   -- Quests:  key: QuestID  value:
   -- Title: string
@@ -1662,7 +1663,7 @@ function addon:UpdateToonData()
       db.Quests[id] = nil
     end
   end
-  addon:UpdateCurrency()
+  core:GetModule("Currency"):UpdateCurrency()
   local zone = GetRealZoneText()
   if zone and #zone > 0 then
     t.Zone = zone
@@ -2401,13 +2402,9 @@ hoverTooltip.ShowSpellIDTooltip = function (cell, arg, ...)
   finishIndicator()
 end
 
-local weeklycap = CURRENCY_WEEKLY_CAP:gsub("%%%d*?([ds])","%%%1")
-local weeklycap_scan = weeklycap:gsub("%%d","(%%d+)"):gsub("%%s","(\124c%%x%%x%%x%%x%%x%%x%%x%%x)")
-weeklycap = weeklycap:gsub("%%d","%%s")
-local totalcap = CURRENCY_TOTAL_CAP:gsub("%%%d*?([ds])","%%%1")
-local totalcap_scan = totalcap:gsub("%%d","(%%d+)"):gsub("%%s","(\124c%%x%%x%%x%%x%%x%%x%%x%%x)")
-totalcap = totalcap:gsub("%%d","%%s")
-local season_scan = CURRENCY_SEASON_TOTAL:gsub("%%%d*?([ds])","(%%%1*)")
+local weeklyCapPatten = gsub(CURRENCY_WEEKLY_CAP, "%%s%%s/%%s", "(.+)")
+local totalCapPatten = gsub(CURRENCY_TOTAL_CAP, "%%s%%s/%%s", "(.+)")
+local seasonTotalPatten = gsub(CURRENCY_SEASON_TOTAL, "%%s%%s", "(.+)")
 
 hoverTooltip.ShowCurrencyTooltip = function (cell, arg, ...)
   local toon, idx, ci = unpack(arg)
@@ -2421,16 +2418,13 @@ hoverTooltip.ShowCurrencyTooltip = function (cell, arg, ...)
   scantt:SetCurrencyByID(idx)
   name = scantt:GetName()
   local spacer
-  for i=1,scantt:NumLines() do
-    local left = _G[name.."TextLeft"..i]
+  for i = 1, scantt:NumLines() do
+    local left = _G[name .. "TextLeft" .. i]
     local text = left:GetText()
-    if text:find(weeklycap_scan) or
-      text:find(totalcap_scan) or
-      text:find(season_scan) then
-    -- omit player's values
-    else
+    if not (strfind(text, weeklyCapPatten) or strfind(text, totalCapPatten) or strfind(text, seasonTotalPatten)) then
+      -- omit player's values
       indicatortip:AddLine("")
-      indicatortip:SetCell(indicatortip:GetLineCount(),1,coloredText(left), nil, "LEFT",2, nil, nil, nil, 250)
+      indicatortip:SetCell(indicatortip:GetLineCount(), 1, coloredText(left), nil, "LEFT", 2, nil, nil, nil, 250)
       spacer = #strtrim(text) == 0
     end
   end
@@ -2439,14 +2433,27 @@ hoverTooltip.ShowCurrencyTooltip = function (cell, arg, ...)
       indicatortip:AddLine(" ")
       spacer = true
     end
-    indicatortip:AddLine(weeklycap:format("", CurrencyColor(ci.earnedThisWeek or 0,ci.weeklyMax), addon:formatNumber(ci.weeklyMax)))
+    indicatortip:AddLine(format(CURRENCY_WEEKLY_CAP, "", CurrencyColor(ci.earnedThisWeek or 0, ci.weeklyMax), addon:formatNumber(ci.weeklyMax)))
   end
   if ci.totalMax and ci.totalMax > 0 then
     if not spacer then
       indicatortip:AddLine(" ")
       spacer = true
     end
-    indicatortip:AddLine(totalcap:format("", CurrencyColor(ci.amount or 0,ci.totalMax), addon:formatNumber(ci.totalMax)))
+    indicatortip:AddLine(format(CURRENCY_TOTAL_CAP, "", CurrencyColor(ci.amount or 0,ci.totalMax), addon:formatNumber(ci.totalMax)))
+  end
+  if addon.specialCurrency[idx] and addon.specialCurrency[idx].relatedItem then
+    if not spacer then
+      indicatortip:AddLine(" ")
+      spacer = true
+    end
+    local itemName = GetItemInfo(addon.specialCurrency[idx].relatedItem.id) or ""
+    if addon.specialCurrency[idx].relatedItem.holdingMax then
+      local holdingMax = addon.specialCurrency[idx].relatedItem.holdingMax
+      indicatortip:AddLine(itemName .. ": " .. CurrencyColor(ci.relatedItemCount or 0, holdingMax) .. "/" .. holdingMax)
+    else
+      indicatortip:AddLine(itemName .. ": " .. (ci.relatedItemCount or 0))
+    end
   end
   if ci.season and #ci.season > 0 then
     if not spacer then
@@ -2468,6 +2475,12 @@ hoverTooltip.ShowCurrencySummary = function (cell, arg, ...)
   if not idx then return end
   local name,_,tex = GetCurrencyInfo(idx)
   tex = " \124T"..tex..":0\124t"
+  local itemFlag, itemIcon
+  if addon.specialCurrency[idx] and addon.specialCurrency[idx].relatedItem then
+    itemFlag = true
+    itemIcon = select(10, GetItemInfo(addon.specialCurrency[idx].relatedItem.id))
+    itemIcon = itemIcon and (" \124T" .. itemIcon .. ":0\124t") or ""
+  end
   openIndicator(2, "LEFT","RIGHT")
   indicatortip:AddHeader(name, "")
   local total = 0
@@ -2477,9 +2490,17 @@ hoverTooltip.ShowCurrencySummary = function (cell, arg, ...)
     local ci = t.currency and t.currency[idx]
     if ci and ci.amount then
       tmax = tmax or ci.totalMax
-      table.insert(temp, { ["toon"] = toon, ["amount"] = ci.amount,
-        ["str1"] = ClassColorise(t.Class, toon),
-        ["str2"] = CurrencyColor(ci.amount or 0,tmax)..tex,
+      local str2 = CurrencyColor(ci.amount or 0, tmax) .. tex
+      if itemFlag then
+        if addon.specialCurrency[idx].relatedItem.holdingMax then
+          str2 = str2 .. " + " .. CurrencyColor(ci.relatedItemCount or 0, addon.specialCurrency[idx].relatedItem.holdingMax) .. itemIcon
+        else
+          str2 = str2 .. " + " .. (ci.relatedItemCount or 0) .. itemIcon
+        end
+      end
+      tinsert(temp, {
+        toon = toon, amount = ci.amount, itemCount = ci.relatedItemCount or 0,
+        str1 = ClassColorise(t.Class, toon), str2 = str2,
       })
       total = total + ci.amount
     end
@@ -2488,10 +2509,10 @@ hoverTooltip.ShowCurrencySummary = function (cell, arg, ...)
   --indicatortip:AddLine(TOTAL, CurrencyColor(total,tmax)..tex)
   --indicatortip:AddLine(" ")
   addon.currency_sort = addon.currency_sort or function(a,b)
-    if a.amount > b.amount then
-      return true
-    elseif a.amount < b.amount then
-      return false
+    if a.amount ~= b.amount then
+      return a.amount > b.amount
+    elseif a.itemCount ~= b.itemCount then
+      return a.itemCount > b.itemCount
     end
     local an, as = a.toon:match('^(.*) [-] (.*)$')
     local bn, bs = b.toon:match('^(.*) [-] (.*)$')
@@ -4203,25 +4224,22 @@ function core:ShowTooltip(anchorframe)
   end
 
   local firstcurrency = true
-  for _,idx in ipairs(currency) do
-    local setting = addon.db.Tooltip["Currency"..idx]
-    if setting or showall then
+  for _, idx in ipairs(currency) do
+    if addon.db.Tooltip["Currency" .. idx] or showall then
       local show
       for toon, t in cpairs(addon.db.Toons, true) do
-        -- ci.name, ci.amount, ci.earnedThisWeek, ci.weeklyMax, ci.totalMax
+        -- ci.name, ci.amount, ci.earnedThisWeek, ci.weeklyMax, ci.totalMax, ci.relatedItemCount
         local ci = t.currency and t.currency[idx]
-        local gotsome
         if ci then
-          gotsome = ((ci.earnedThisWeek or 0) > 0 and (ci.weeklyMax or 0) > 0) or
-            ((ci.amount or 0) > 0 and showall)
-          -- or ((ci.amount or 0) > 0 and ci.weeklyMax == 0 and t.Level == maxlvl)
-        end
-        if ci and gotsome then
-          addColumns(columns, toon, tooltip)
-        end
-        if ci and (gotsome or (ci.amount or 0) > 0) and columns[toon..1] then
-          local name,_,tex = GetCurrencyInfo(idx)
-          show = string.format(" \124T%s:0\124t%s",tex,name)
+          local gotThisWeek = ((ci.earnedThisWeek or 0) > 0 and (ci.weeklyMax or 0) > 0)
+          local gotSome = ((ci.relatedItemCount or 0) > 0) or ((ci.amount or 0) > 0)
+          if gotThisWeek or (gotSome and showall) then
+            addColumns(columns, toon, tooltip)
+          end
+          if not show and (gotThisWeek or gotSome) and columns[toon .. 1] then
+            local name, _, tex = GetCurrencyInfo(idx)
+            show = format(" \124T%s:0\124t%s", tex, name)
+          end
         end
       end
       local currLine
@@ -4258,6 +4276,18 @@ function core:ShowTooltip(anchorframe)
                 str = earned.." ("..CurrencyColor(ci.earnedThisWeek,ci.weeklyMax)..weeklymax..")"
               elseif (ci.amount or 0) > 0 then
                 str = CurrencyColor(ci.amount,ci.totalMax)..totalmax
+              end
+              if addon.specialCurrency[idx] and addon.specialCurrency[idx].relatedItem then
+                if addon.specialCurrency[idx].relatedItem.holdingMax then
+                  local holdingMax = addon.specialCurrency[idx].relatedItem.holdingMax
+                  if addon.db.Tooltip.CurrencyMax then
+                    str = str .. " (" .. CurrencyColor(ci.relatedItemCount or 0, holdingMax) .. "/" .. holdingMax .. ")"
+                  else
+                    str = str .. " (" .. CurrencyColor(ci.relatedItemCount or 0, holdingMax) .. ")"
+                  end
+                else
+                  str = str .. " (" .. (ci.relatedItemCount or 0) .. ")"
+                end
               end
             end
             if str then

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -753,8 +753,9 @@ function addon:QuestIgnored(questID)
       return
     end
     return true
+  elseif core:GetModule("Progress"):QuestEnabled(questID) then
+    return true
   end
-  return
 end
 
 function addon:QuestCount(toonname)

--- a/SavedInstances/Warfront.lua
+++ b/SavedInstances/Warfront.lua
@@ -36,12 +36,12 @@ local warfronts = {
   {
     Alliance = {
       id = 117,
-      scenario = {53992}, -- Warfront: The Battle for Darkshore (Alliance)
+      scenario = {53992, 57960}, -- Warfront: The Battle for Darkshore (Alliance)
       boss = 54895, -- Ivus the Decayed
     },
     Horde = {
       id = 118,
-      scenario = {53955}, -- Warfront: The Battle for Darkshore (Horde)
+      scenario = {53955, 57959}, -- Warfront: The Battle for Darkshore (Horde)
       boss = 54896, -- Ivus the Forest Lord
     },
   },


### PR DESCRIPTION
* Add related item count to specific currency (closes #337 )
* Make Daily and Weekly Quest only ignore quests which are shown in Progress
* Add heroic warfront and pet battle dungeon quests