### PR TITLE
optional currency sort by name

### DIFF
--- a/SavedInstances/Currency.lua
+++ b/SavedInstances/Currency.lua
@@ -64,6 +64,17 @@ local currency = {
 }
 addon.currency = currency
 
+local currencySorted = {}
+for _, idx in ipairs(currency) do
+  table.insert(currencySorted, idx)
+end
+table.sort(currency, function (c1, c2)
+  local c1_name = GetCurrencyInfo(c1)
+  local c2_name = GetCurrencyInfo(c2)
+  return c1_name < c2_name
+end)
+addon.currencySorted = currencySorted
+
 local specialCurrency = {
   [1129] = { -- WoD - Seal of Tempered Fate
     weeklyMax = 3,

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -473,6 +473,7 @@ addon.defaultDB = {
     Currency1721 = true, -- Prismatic Manapearl
     CurrencyMax = false,
     CurrencyEarned = true,
+    CurrencySortName = false,
     MythicKey = true,
     MythicKeyBest = true,
     Emissary6 = false, -- LEG Emissary
@@ -4225,7 +4226,11 @@ function core:ShowTooltip(anchorframe)
   end
 
   local firstcurrency = true
-  for _, idx in ipairs(currency) do
+  local ckeys = currency
+  if addon.db.Tooltip.CurrencySortName then
+    ckeys = addon.currencySorted
+  end
+  for _, idx in ipairs(ckeys) do
     if addon.db.Tooltip["Currency" .. idx] or showall then
       local show
       for toon, t in cpairs(addon.db.Toons, true) do

--- a/SavedInstances/config.lua
+++ b/SavedInstances/config.lua
@@ -528,8 +528,13 @@ function Config:BuildOptions()
             order = 40,
             name = L["Show currency earned"]
           },
-          CurrencyHeader = {
+          CurrencySortName = {
+            type = "toggle",
             order = 50,
+            name = L["Sort by currency name"],
+          },
+          CurrencyHeader = {
+            order = 60,
             type = "header",
             name = CURRENCY,
           },
@@ -867,12 +872,13 @@ function Config:BuildOptions()
       name = _G["EXPANSION_NAME" .. expansion],
     }
   end
+  local hdroffset = core.Options.args.Currency.args.CurrencyHeader.order
   for i, curr in ipairs(addon.currency) do
     local name,_,tex = GetCurrencyInfo(curr)
     tex = "\124T"..tex..":0\124t "
     core.Options.args.Currency.args["Currency"..curr] = {
       type = "toggle",
-      order = 50+i,
+      order = hdroffset+i,
       name = tex..name,
     }
   end


### PR DESCRIPTION
Add Currency option "Sort by currency name" (CurrencySortName)
to toggle the currency sort order between
currency ID (default) and currency name.

Simplify addition of new Currency options to always order
specific currencies after the header.