### PR TITLE
core: format currencies over cap as capped

### DIFF
--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -505,7 +505,7 @@ local function CurrencyColor(amt, max)
   if SI.db.Tooltip.CurrencyValueColor then
     local pct = amt / max
     local color = GREENFONT
-    if pct == 1 then
+    if pct >= 1 then
       color = REDFONT
     elseif pct > 0.75 then
       color = GOLDFONT


### PR DESCRIPTION
On retail currently it's possible to exceed the Redeemed Souls cap when you turn in the weekly quest while just under the cap. This change will format currency amounts over cap as if they were capped (red font).