### PR TITLE
currency: add totalEarned for earn-capped currency

### DIFF
--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -158,6 +158,7 @@ SI.defaultDB = {
   -- weeklyMax: integer
   -- totalMax: integer
   -- season: integer
+  -- totalEarned: integer
   -- relatedItemCount: integer
 
   -- Quests:  key: QuestID  value:
@@ -2271,12 +2272,18 @@ hoverTooltip.ShowCurrencyTooltip = function (cell, arg, ...)
     end
     indicatortip:AddLine(format(CURRENCY_WEEKLY_CAP, "", CurrencyColor(ci.earnedThisWeek or 0, ci.weeklyMax), SI:formatNumber(ci.weeklyMax)))
   end
-  if ci.totalMax and ci.totalMax > 0 then
+  if ci.totalEarned and ci.totalEarned > 0 and ci.totalMax and ci.totalMax > 0 then
     if not spacer then
       indicatortip:AddLine(" ")
       spacer = true
     end
-    indicatortip:AddLine(format(CURRENCY_TOTAL_CAP, "", CurrencyColor(ci.amount or 0,ci.totalMax), SI:formatNumber(ci.totalMax)))
+    indicatortip:AddLine(format(CURRENCY_TOTAL_CAP, "", CurrencyColor(ci.totalEarned or 0, ci.totalMax), SI:formatNumber(ci.totalMax)))
+  elseif ci.totalMax and ci.totalMax > 0 then
+    if not spacer then
+      indicatortip:AddLine(" ")
+      spacer = true
+    end
+    indicatortip:AddLine(format(CURRENCY_TOTAL_CAP, "", CurrencyColor(ci.amount or 0, ci.totalMax), SI:formatNumber(ci.totalMax)))
   end
   if SI.specialCurrency[idx] and SI.specialCurrency[idx].relatedItem then
     if not spacer then

--- a/SavedInstances/Modules/Currency.lua
+++ b/SavedInstances/Modules/Currency.lua
@@ -176,13 +176,15 @@ function Module:UpdateCurrency()
   t.currency = wipe(t.currency or {})
   for _,idx in ipairs(currency) do
     local data = C_CurrencyInfo_GetCurrencyInfo(idx)
-    local amount, earnedThisWeek, weeklyMax, totalMax, discovered =
-      data.quantity, data.quantityEarnedThisWeek, data.maxWeeklyQuantity, data.maxQuantity, data.discovered
-    if not discovered then
+    if not data.discovered then
       t.currency[idx] = nil
     else
       local ci = t.currency[idx] or {}
-      ci.amount, ci.earnedThisWeek, ci.weeklyMax, ci.totalMax = amount, earnedThisWeek, weeklyMax, totalMax
+      ci.amount = data.quantity
+      ci.totalMax = data.maxQuantity
+      ci.earnedThisWeek = data.quantityEarnedThisWeek
+      ci.weeklyMax = data.maxWeeklyQuantity
+      ci.totalEarned = data.totalEarned
       -- handle special currency
       if specialCurrency[idx] then
         local tbl = specialCurrency[idx]
@@ -204,9 +206,11 @@ function Module:UpdateCurrency()
         ci.totalMax = ci.totalMax + 1
       end
       ci.season = GetSeasonCurrency(idx)
-      if ci.weeklyMax == 0 then ci.weeklyMax = nil end -- don't store useless info
-      if ci.totalMax == 0 then ci.totalMax = nil end -- don't store useless info
-      if ci.earnedThisWeek == 0 then ci.earnedThisWeek = nil end -- don't store useless info
+      -- don't store useless info
+      if ci.weeklyMax == 0 then ci.weeklyMax = nil end
+      if ci.totalMax == 0 then ci.totalMax = nil end
+      if ci.earnedThisWeek == 0 then ci.earnedThisWeek = nil end
+      if ci.totalEarned == 0 then ci.totalEarned = nil end
       t.currency[idx] = ci
     end
   end


### PR DESCRIPTION
`Conquest` and `Valor` have increasing cap week by week, and show as `Total Maximum: X/Y` on BLZ currency tooltip, where X is `.totalEarned`.

![01](https://user-images.githubusercontent.com/3353011/110774571-e85d4a80-8298-11eb-8a04-adce4863dace.png)

Currently SI ignores `.totalEarned` and simply uses `.quantity` on tooltip. This PR make SI stores `.totalEarned` and use it if present.