### PR TITLE
feat: add tormentors of torghast to events

### DIFF
--- a/SavedInstances/Modules/WorldBoss.lua
+++ b/SavedInstances/Modules/WorldBoss.lua
@@ -80,4 +80,5 @@ SI.WorldBosses = {
   [9005] = { quest=60542, name=L["Nathanos Blightcaller"], expansion=7, level=50 }, -- Nathanos Blightcaller
   -- The Maw
   [9006] = { quest=63414, name=L["Wrath of the Jailer"], expansion=8, level=60 }, -- Wrath of the Jailer
+  [9007] = { quest=63854, name=L["Tormentors of Torghast"], expansion=8, level=60 }, -- Tormentors of Torghast
 }


### PR DESCRIPTION
This PR adds a tracking event under world bosses (as it is the closest definition of it) for the weekly event in the Maw, Tormentors of Torghast. It does so by tracking quest ID 63854, which is an internal quest ticker:

![image](https://user-images.githubusercontent.com/3967363/124386210-a6d62c80-dcd9-11eb-9f1a-3aa9269239ad.png)
