### PR TITLE
Fix regex to catch more than two digits: fixes #528

### DIFF
--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -205,7 +205,7 @@ local function TorghastUpdate(index)
 
     if nameInfo and levelInfo then
       local available = nameInfo.shownState == 1
-      local levelText = strmatch(levelInfo.text, '|cFF00FF00.+(%d+).+|r')
+      local levelText = strmatch(levelInfo.text, '|cFF00FF00.-(%d+).+|r')
 
       SI.db.Toons[SI.thisToon].Progress[index]['Available' .. i] = available
       SI.db.Toons[SI.thisToon].Progress[index]['Level' .. i] = levelText


### PR DESCRIPTION
As the level of torghast became a two-digit number, it seems that the existing regular expression could not catch the `levelText` properly, causing the problem like #528.
I changed it to select the shortest pattern before digits, so that the digits will be chosen as long as possible.