### PR TITLE
Trade Skill and Quest Update

### DIFF
--- a/SavedInstances/Modules/Quest.lua
+++ b/SavedInstances/Modules/Quest.lua
@@ -64,6 +64,12 @@ local _specialQuests = {
   [63198] = { name=L["Hunt: Death Elementals"] },   -- Hunt: Death Elementals
   [63199] = { name=L["Hunt: Soul Eaters"] },        -- Hunt: Soul Eaters
 
+  -- Covenant Assaults
+  [63543] = { zid=1543 }, -- Necrolord Assault
+  [63822] = { zid=1543 }, -- Venthyr Assault
+  [63823] = { zid=1543 }, -- Night Fae Assault
+  [63824] = { zid=1543 }, -- Kyrian Assault
+
   -- Old Vanilla Bosses during Anniversary Event
   [47461] = { daily=true, name=L["Lord Kazzak"] },          -- Lord Kazzak
   [47462] = { daily=true, name=L["Azuregos"] },             -- Azuregos
@@ -257,11 +263,6 @@ local QuestExceptions = {
   [62449] = "Weekly", -- A Spirit's Duty
   [62450] = "Weekly", -- A Spirit's Heart
   [62452] = "Weekly", -- A Spirit's Might
-  -- Covenant Assaults
-  [63543] = "Weekly", -- Necrolord Assault
-  [63822] = "Weekly", -- Venthyr Assault
-  [63823] = "Weekly", -- Night Fae Assault
-  [63824] = "Weekly", -- Kyrian Assault
 
   -- General
   -- Darkmoon Faire

--- a/SavedInstances/Modules/TradeSkill.lua
+++ b/SavedInstances/Modules/TradeSkill.lua
@@ -113,6 +113,7 @@ local trade_spells = {
   -- SL
   [307142] = true, -- Shadowghast Ingot
   [307143] = true, -- Shadestone
+  [307144] = true, -- Stones to Ore
 
   -- Enchanting
   [28027]  = "sphere", -- Prismatic Sphere (2-day shared, 5.2.0 verified)


### PR DESCRIPTION
* new Transmute trade skill added in patch 9.1, fixes #532
* fix Covenant Assaults tracking, use specialQuests to fetch them more often
  Normally turning in quest will call `GetQuestReward` which SI hooks, but hidden tracking quest, World Quests or Bonus Objective won't, like daily world quest in Mechagon.
  I'm trying to track them by `QUEST_TURNED_IN` event but need more test (need to wait for next darkmoon). So put Covenant Assaults quest in specialQuests to make them trackable before reload after complete.