### PR TITLE
fix(LFR): no longer require special remap

### DIFF
--- a/SavedInstances/Modules/LFR.lua
+++ b/SavedInstances/Modules/LFR.lua
@@ -140,8 +140,6 @@ for id, info in pairs(LFRInstances) do
       info.remap = { 3, 5, 7 }
     elseif id == 2092 then -- Castle Nathria: Blood from Stone
       info.remap = { 1, 8, 9 }
-    elseif id == 2222 then -- Sanctum of Domination: The Dark Bastille
-      info.remap = { 5, 4, 6 }
     end
   end
 


### PR DESCRIPTION
Blizzard changed the encounter order in Sanctum of Domination in build 9.1.0.39335, which matches the order of LFR wing 2. So it'll no longer require special remap on wing 2.