### PR TITLE
feat(Progress): add Covenant Assaults

### DIFF
--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -379,6 +379,7 @@ SI.defaultDB = {
     Progress4 = false, -- N'Zoth Assaults
     Progress5 = false, -- Lesser Visions of N'Zoth
     Progress6 = true, -- Torghast Weekly
+    Progress7 = true, -- Covenant Assaults
     Warfront1 = false, -- Arathi Highlands
     Warfront2 = false, -- Darkshores
     KeystoneReportTarget = "EXPORT",
@@ -2422,6 +2423,29 @@ hoverTooltip.ShowTorghastTooltip = function (cell, arg, ...)
 
       indicatortip:AddLine(nameText, t.Progress[index]['Level' .. i])
     end
+  end
+
+  finishIndicator()
+end
+
+hoverTooltip.ShowCovenantAssaultTooltip = function (cell, arg, ...)
+  -- Should be in Module Progress
+  local toon, index = unpack(arg)
+  local t = SI.db.Toons[toon]
+  if not t or not t.Progress or not t.Progress[index] then return end
+  if not t or not t.Quests then return end
+  openIndicator(2, "LEFT", "RIGHT")
+  indicatortip:AddHeader(ClassColorise(t.Class, toon), L["Covenant Assaults"])
+
+  local P = SI:GetModule("Progress")
+  for _, questID in ipairs(P.TrackedQuest[index].relatedQuest) do
+    indicatortip:AddLine(SI:QuestInfo(questID),
+      t.Quests[questID] and (REDFONT .. CRITERIA_COMPLETED .. FONTEND) or (
+        t.Progress[index][questID] and
+        (GREENFONT .. AVAILABLE .. FONTEND) or
+        (REDFONT .. ADDON_NOT_AVAILABLE .. FONTEND)
+      )
+    )
   end
 
   finishIndicator()

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -399,7 +399,7 @@ Module.TrackedQuest = {
       63824, -- Kyrian Assault
       63543, -- Necrolord Assault
     },
-  }, 
+  },
   {
     name = L["The World Awaits"],
     weekly = true,

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -239,6 +239,41 @@ local function TorghastReset(toon, index)
   t.Progress[index].unlocked = unlocked
 end
 
+-- Covenant Assaults (index 7)
+
+local function CovenantAssaultUpdate(index)
+  SI.db.Toons[SI.thisToon].Progress[index] = wipe(SI.db.Toons[SI.thisToon].Progress[index] or {})
+  for _, questID in ipairs(Module.TrackedQuest[index].relatedQuest) do
+    SI.db.Toons[SI.thisToon].Progress[index][questID] = C_TaskQuest_IsActive(questID)
+  end
+  SI.db.Toons[SI.thisToon].Progress[index].unlocked = IsQuestFlaggedCompleted(64556) -- In Need of Assistance
+end
+
+local function CovenantAssaultShow(toon, index)
+  local t = SI.db.Toons[toon]
+  if not t or not t.Quests then return end
+  if not t or not t.Progress or not t.Progress[index] then return end
+
+  if t.Progress[index].unlocked then
+    local count = 0
+    for _, questID in ipairs(Module.TrackedQuest[index].relatedQuest) do
+      if t.Quests[questID] then
+        count = count + 1
+      end
+    end
+    return count == 0 and "" or tostring(count)
+  end
+end
+
+local function CovenantAssaultReset(toon, index)
+  local t = SI.db.Toons[toon]
+  if not t or not t.Progress or not t.Progress[index] then return end
+
+  local unlocked = t.Progress[index].unlocked
+  wipe(t.Progress[index])
+  t.Progress[index].unlocked = unlocked
+end
+
 Module.TrackedQuest = {
   -- Conquest
   {
@@ -350,6 +385,21 @@ Module.TrackedQuest = {
       {2929, 2940}, -- The Upper Reaches
     },
   },
+  -- Covenant Assaults
+  {
+    name = L["Covenant Assaults"],
+    weekly = true,
+    func = CovenantAssaultUpdate,
+    showFunc = CovenantAssaultShow,
+    resetFunc = CovenantAssaultReset,
+    tooltipKey = 'ShowCovenantAssaultTooltip',
+    relatedQuest = {
+      63823, -- Night Fae Assault
+      63822, -- Venthyr Assault
+      63824, -- Kyrian Assault
+      63543, -- Necrolord Assault
+    },
+  }, 
   {
     name = L["The World Awaits"],
     weekly = true,


### PR DESCRIPTION
I wanted to see Covenant Assaults tracked in the same way N'Zoth Assaults are tracked, so I just used that code as the basis for these changes.

Copying code you don't completely understand is always a little dangerous, so you might want to check to make sure I haven't done something wrong here.