### PR TITLE
feat(World Boss): add Doomwalker

### DIFF
--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -2068,7 +2068,7 @@ hoverTooltip.ShowLFRTooltip = function (cell, arg, ...)
   local boxname, toon, tbl = unpack(arg)
   local t = SI.db.Toons[toon]
   if not boxname or not t or not tbl then return end
-  openIndicator(3, "LEFT", "LEFT","RIGHT")
+  openIndicator(3, "LEFT", "LEFT", "RIGHT")
   local line = indicatortip:AddHeader()
   local toonstr = (db.Tooltip.ShowServer and toon) or strsplit(' ', toon)
   local reset = t.WeeklyResetTime or SI:GetNextWeeklyResetTime()
@@ -3126,7 +3126,7 @@ function SI:Refresh(recoverdaily)
       local info = instance[SI.thisToon][2] or {}
       wipe(info)
       instance[SI.thisToon][2] = info
-      info.Expires = weeklyreset
+      info.Expires = einfo.daily and nextreset or weeklyreset
       info.ID = -1
       info[1] = true
     end

--- a/SavedInstances/Modules/WorldBoss.lua
+++ b/SavedInstances/Modules/WorldBoss.lua
@@ -82,4 +82,6 @@ SI.WorldBosses = {
   -- The Maw
   [9006] = { quest=63414, name=L["Wrath of the Jailer"],    expansion=8, level=60 }, -- Wrath of the Jailer
   [9007] = { quest=63854, name=L["Tormentors of Torghast"], expansion=8, level=60 }, -- Tormentors of Torghast
+  -- Anniversary event
+  [9008] = { quest=60214, name=L["Doomwalker"], expansion=7, level=30, daily=true }, -- Doomwalker
 }


### PR DESCRIPTION
It's a daily reset (presumably).

I'm not sure if you need Shadowlands expansion or not to be eligible to loot, although it's just in Tanaris and you're eligible to loot at level 30 so assuming not (used expansion=7, maybe expansion=1 is better?).