### PR TITLE
fix(MythicPlus): threshold update

### DIFF
--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -1905,7 +1905,7 @@ hoverTooltip.ShowMythicPlusTooltip = function (cell, arg, ...)
   indicatortip:AddHeader(ClassColorise(t.Class, toon), text)
   if t.MythicKeyBest.runHistory and #t.MythicKeyBest.runHistory > 0 then
     local maxThreshold = t.MythicKeyBest.threshold and t.MythicKeyBest.threshold[#t.MythicKeyBest.threshold]
-    local displayNumber = min(#t.MythicKeyBest.runHistory, maxThreshold or 10)
+    local displayNumber = min(#t.MythicKeyBest.runHistory, maxThreshold or 8)
     indicatortip:AddLine()
     indicatortip:SetCell(2, 1, format(WEEKLY_REWARDS_MYTHIC_TOP_RUNS, displayNumber), "LEFT", 2)
     for i = 1, displayNumber do


### PR DESCRIPTION
Starting March 1 the max reward threshold for M+ is being reduced from 10 to 8:

https://us.forums.blizzard.com/en/wow/t/1190152/1

This just updates the fallback value to match.