### PR TITLE
use GetSavedInstanceInfo to track previous expansion LFRs

### DIFF
--- a/SavedInstances/Core/Config.lua
+++ b/SavedInstances/Core/Config.lua
@@ -75,6 +75,8 @@ function SI:idtext(instance,diff,info)
     return SI.diff_strings["R"..(diff-2)]
   elseif diff >= 14 and diff <= 16 then -- WoD raids
     return SI.diff_strings["R"..(diff-8)]
+  elseif diff == 17 then -- Looking For Raid
+    return SI.diff_strings.R5
   else
     return ""
   end


### PR DESCRIPTION
`GetLFGDungeonNumEncounters` and `GetLFGDungeonEncounterInfo` is currently bugged and won't return boss killed in previous expansion LFRs. (See Stanzilla/WoWUIBugs#222) So `GetSavedInstanceInfo` is our only way to track them.

This PR basically revert 62ecf70 and 205643a, and add some stuffs for distinguishing LFR from normal.