### PR TITLE
fix(WorldBoss): update Fated World Boss quest IDs

### DIFF
--- a/SavedInstances/Modules/WorldBoss.lua
+++ b/SavedInstances/Modules/WorldBoss.lua
@@ -84,10 +84,10 @@ SI.WorldBosses = {
   [9006] = { quest=63414, name=L["Wrath of the Jailer"],    expansion=8, level=60 }, -- Wrath of the Jailer
   [9007] = { quest=63854, name=L["Tormentors of Torghast"], expansion=8, level=60 }, -- Tormentors of Torghast
   -- Fated (Shadowlands Season 4)
-  -- [9008] = { quest=61813, name=EJ_GetEncounterInfo(2430), expansion=8, level=60 }, -- Valinor, the Light of Eons
-  -- [9009] = { quest=61816, name=EJ_GetEncounterInfo(2431), expansion=8, level=60 }, -- Mortanis
-  -- [9010] = { quest=61815, name=EJ_GetEncounterInfo(2432), expansion=8, level=60 }, -- Oranomonos the Everbranching
+  [9008] = { quest=66614, name=EJ_GetEncounterInfo(2430), expansion=8, level=60 }, -- Valinor, the Light of Eons
+  [9009] = { quest=66617, name=EJ_GetEncounterInfo(2431), expansion=8, level=60 }, -- Mortanis
+  [9010] = { quest=66616, name=EJ_GetEncounterInfo(2432), expansion=8, level=60 }, -- Oranomonos the Everbranching
   [9011] = { quest=66615, name=EJ_GetEncounterInfo(2433), expansion=8, level=60 }, -- Nurgash Muckformed
-  -- [9012] = { quest=64531, name=EJ_GetEncounterInfo(2456), expansion=8, level=60 }, -- Mor'geth, Tormentor of the Damned
-  -- [9013] = { quest=65143, name=EJ_GetEncounterInfo(2468), expansion=8, level=60 }, -- Antros
+  [9012] = { quest=66618, name=EJ_GetEncounterInfo(2456), expansion=8, level=60 }, -- Mor'geth, Tormentor of the Damned
+  [9013] = { quest=66619, name=EJ_GetEncounterInfo(2468), expansion=8, level=60 }, -- Antros
 }


### PR DESCRIPTION
Quest IDs from QuestV2CliTask table: https://wow.tools/dbc/?dbc=questv2clitask&build=9.2.5.44908#page=1&colFilter[20]=2426

Fixes #602