### PR TITLE
fix: changelogs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,9 @@ jobs:
       WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # gets git history for changelogs
 
       - name: Install and run Luacheck
         uses: nebularg/actions-luacheck@v1


### PR DESCRIPTION
I noticed in the Curseforge app the changelog for each version only contained the most recent commit instead of all commits since the last version. The reason is because the default fetch-depth for actions/checkout is 1, this is what the BigWigs packager uses for its automatic changelog generation. This fixes [git release changelogs](https://github.com/SavedInstances/SavedInstances/releases/tag/10.0.3) as well.