### PR TITLE
Several Updates

### DIFF
--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -2563,6 +2563,25 @@ hoverTooltip.ShowDragonflightRenownTooltip = function (cell, arg, ...)
   finishIndicator()
 end
 
+hoverTooltip.ShowAidingTheAccordTooltip = function (cell, arg, ...)
+  -- Should be in Module Progress
+  local toon, index = unpack(arg)
+  local t = SI.db.Toons[toon]
+  if not t or not t.Progress or not t.Progress[index] then return end
+  if not t or not t.Quests then return end
+  openIndicator(2, "LEFT", "RIGHT")
+  indicatortip:AddHeader(ClassColorise(t.Class, toon), L["Aiding the Accord"])
+
+  if t.Progress[index].leaderboardCount and t.Progress[index].leaderboardCount > 0 then
+    for i = 1, t.Progress[index].leaderboardCount do
+      indicatortip:AddLine("")
+      indicatortip:SetCell(i + 1, 1, t.Progress[index][i], nil, "LEFT", 2)
+    end
+  end
+
+  finishIndicator()
+end
+
 hoverTooltip.ShowGrandHuntTooltip = function (cell, arg, ...)
   -- Should be in Module Progress
   local toon, index = unpack(arg)

--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -2534,7 +2534,9 @@ hoverTooltip.ShowDragonflightRenownTooltip = function (cell, arg, ...)
   indicatortip:AddHeader(ClassColorise(t.Class, toon), L["Dragonflight Renown"])
 
   local majorFactionIDs = C_MajorFactions.GetMajorFactionIDs(LE_EXPANSION_DRAGONFLIGHT)
-  for _, factionID in ipairs(majorFactionIDs) do
+
+  local factionIDs = SI:GetModule("Progress").TrackedQuest[index].factionIDs
+  for _, factionID in ipairs(factionIDs) do
     if t.Progress[index][factionID] then
       indicatortip:AddLine(
         C_MajorFactions.GetMajorFactionData(factionID).name,
@@ -2542,6 +2544,19 @@ hoverTooltip.ShowDragonflightRenownTooltip = function (cell, arg, ...)
       )
     else
       indicatortip:AddLine(C_MajorFactions.GetMajorFactionData(factionID).name, LOCKED)
+    end
+  end
+
+  for _, factionID in ipairs(majorFactionIDs) do
+    if not tContains(factionIDs, factionID) then
+      if t.Progress[index][factionID] then
+        indicatortip:AddLine(
+          C_MajorFactions.GetMajorFactionData(factionID).name,
+          format("%s %s (%s/%s)", COVENANT_SANCTUM_TAB_RENOWN, unpack(t.Progress[index][factionID]))
+        )
+      else
+        indicatortip:AddLine(C_MajorFactions.GetMajorFactionData(factionID).name, LOCKED)
+      end
     end
   end
 

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -295,11 +295,23 @@ local function DragonflightRenownShow(toon, index)
 
   local text
   local majorFactionIDs = C_MajorFactions.GetMajorFactionIDs(LE_EXPANSION_DRAGONFLIGHT)
-  for i, factionID in ipairs(majorFactionIDs) do
-    if i == 1 then
+
+  local factionIDs = Module.TrackedQuest[index].factionIDs
+  for _, factionID in ipairs(factionIDs) do
+    if not text then
       text = t.Progress[index][factionID] and t.Progress[index][factionID][1] or '0'
     else
       text = text .. ' / ' .. (t.Progress[index][factionID] and t.Progress[index][factionID][1] or '0')
+    end
+  end
+
+  for _, factionID in ipairs(majorFactionIDs) do
+    if not tContains(factionIDs, factionID) then
+      if not text then
+        text = t.Progress[index][factionID] and t.Progress[index][factionID][1] or '0'
+      else
+        text = text .. ' / ' .. (t.Progress[index][factionID] and t.Progress[index][factionID][1] or '0')
+      end
     end
   end
 
@@ -585,6 +597,12 @@ Module.TrackedQuest = {
     showFunc = DragonflightRenownShow,
     resetFunc = DragonflightRenownReset,
     tooltipKey = 'ShowDragonflightRenownTooltip',
+    factionIDs = {
+      2507, -- Dragonscale Expedition
+      2503, -- Maruuk Centaur
+      2511, -- Iskaara Tuskarr
+      2510, -- Valdrakken Accord
+    },
   },
   {
     name = L["Aiding the Accord"],

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -636,13 +636,13 @@ Module.TrackedQuest = {
     tooltipKey = 'ShowGrandHuntTooltip',
   },
   {
-    name = L["Trial of the Elements"],
+    name = L["Trial of Elements"],
     weekly = true,
     quest = 71995,
     relatedQuest = {71995},
   },
   {
-    name = L["Trial of the Flood"],
+    name = L["Trial of Flood"],
     weekly = true,
     quest = 71033,
     relatedQuest = {71033},

--- a/SavedInstances/Modules/Quest.lua
+++ b/SavedInstances/Modules/Quest.lua
@@ -449,12 +449,12 @@ local QuestExceptions = {
   -- [62632] = "Weekly", -- A Burning Path Through Time - TBC Timewalking
   -- [62633] = "Weekly", -- A Frozen Path Through Time - WLK Timewalking
   -- [62634] = "Weekly", -- A Shattered Path Through Time - CTM Timewalking
-  -- [62635] = "Weekly", -- A Shattered Path Through Time - MOP Timewalking
-  -- [62636] = "Weekly", -- A Savage Path Through Time - WOD Timewalking
+  [72725] = "Weekly", -- A Shrouded Path Through Time - MOP Timewalking
+  [72724] = "Weekly", -- A Savage Path Through Time - WOD Timewalking
   [72723] = "Weekly", -- A Call to Battle - Battlegrounds
   [72722] = "Weekly", -- Emissary of War - Mythic Dungeons
   -- [62639] = "AccountWeekly", -- The Very Best - PvP Pet Battles
-  -- [62640] = "Weekly", -- The Arena Calls - Arena Skirmishes
+  [72720] = "Weekly", -- The Arena Calls - Arena Skirmishes
 }
 SI.QuestExceptions = QuestExceptions
 

--- a/SavedInstances/Modules/Quest.lua
+++ b/SavedInstances/Modules/Quest.lua
@@ -347,6 +347,12 @@ local QuestExceptions = {
   [64522] = "Weekly", -- Stolen Korthian Supplies
 
   -- DF
+  -- Aiding the Accord
+  [70750] = "Weekly", -- Aiding the Accord
+  [72068] = "Weekly", -- Aiding the Accord: A Feast For All
+  [72373] = "Weekly", -- Aiding the Accord: The Hunt is On
+  [72374] = "Weekly", -- Aiding the Accord: Dragonbane Keep
+  [72375] = "Weekly", -- Aiding the Accord: The Isles Call
   -- Fishing Weeklies
   [70199] = "Weekly", -- Catch and Release: Scalebelly Mackerel
   [70200] = "Weekly", -- Catch and Release: Thousandbite Piranha


### PR DESCRIPTION
* Update Weekend Event quest id
* Update Dragonflight Renown tracking display order to the same as Dragon Isle Summary (closes #671 )
* Track Aiding the Accord with 4 alts that has additional requirement (closes #672 )
* Update Trial of Elements and Trial of Flood to use the same name in quest