### PR TITLE
More Update to Patch 10.1 and Dragonflight Season 2

### DIFF
--- a/SavedInstances/Core/Config.lua
+++ b/SavedInstances/Core/Config.lua
@@ -910,9 +910,11 @@ function Config:BuildOptions()
     }
   end
   local hdroffset = SI.Options.args.Currency.args.CurrencyHeader.order
+  local CurrencyModule = SI:GetModule('Currency')
   for i, curr in ipairs(SI.currency) do
     local data = C_CurrencyInfo_GetCurrencyInfo(curr)
-    local name, tex = data.name, data.iconFileID
+    local name = CurrencyModule.OverrideName[idx] or data.name
+    local tex = CurrencyModule.OverrideTexture[idx] or data.iconFileID
     tex = "\124T"..tex..":0\124t "
     SI.Options.args.Currency.args["Currency"..curr] = {
       type = "toggle",

--- a/SavedInstances/Core/Config.lua
+++ b/SavedInstances/Core/Config.lua
@@ -913,8 +913,8 @@ function Config:BuildOptions()
   local CurrencyModule = SI:GetModule('Currency')
   for i, curr in ipairs(SI.currency) do
     local data = C_CurrencyInfo_GetCurrencyInfo(curr)
-    local name = CurrencyModule.OverrideName[idx] or data.name
-    local tex = CurrencyModule.OverrideTexture[idx] or data.iconFileID
+    local name = CurrencyModule.OverrideName[curr] or data.name
+    local tex = CurrencyModule.OverrideTexture[curr] or data.iconFileID
     tex = "\124T"..tex..":0\124t "
     SI.Options.args.Currency.args["Currency"..curr] = {
       type = "toggle",

--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -30,6 +30,8 @@ local currency = SI.currency
 local QuestExceptions = SI.QuestExceptions
 local TimewalkingItemQuest = SI.TimewalkingItemQuest
 
+local CurrencyModule = SI:GetModule('Currency')
+
 SI.Indicators = {
   ICON_STAR = ICON_LIST[1] .. "16:16:0:0|t",
   ICON_CIRCLE = ICON_LIST[2] .. "16:16:0:0|t",
@@ -1885,7 +1887,8 @@ hoverTooltip.ShowEmissaryTooltip = function (cell, arg, ...)
       text = GetMoneyString(info.questReward.money)
     elseif info.questReward.currencyID then
       local data = C_CurrencyInfo.GetCurrencyInfo(info.questReward.currencyID)
-      text = "\124T" .. data.iconFileID .. ":0\124t " .. info.questReward.quantity
+      local iconID = CurrencyModule.OverrideTexture[info.questReward.currencyID] or data.iconFileID
+      text = "\124T" .. iconID .. ":0\124t " .. info.questReward.quantity
     end
     indicatortip:AddLine()
     indicatortip:SetCell(3, 1, text, "RIGHT", 2)
@@ -1997,7 +2000,7 @@ hoverTooltip.ShowBonusTooltip = function (cell, arg, ...)
   for i,roll in ipairs(t.BonusRoll) do
     if i > 10 then break end
     local line = indicatortip:AddLine()
-    local icon = roll.costCurrencyID and C_CurrencyInfo.GetCurrencyInfo(roll.costCurrencyID).iconFileID
+    local icon = roll.costCurrencyID and (CurrencyModule.OverrideTexture[roll.costCurrencyID] or C_CurrencyInfo.GetCurrencyInfo(roll.costCurrencyID).iconFileID)
     if icon then
       indicatortip:SetCell(line,1, " \124T"..icon..":0\124t ")
     end
@@ -2008,7 +2011,7 @@ hoverTooltip.ShowBonusTooltip = function (cell, arg, ...)
       indicatortip:SetCell(line,3,roll.item)
     elseif roll.currencyID then
       local data = C_CurrencyInfo.GetCurrencyInfo(roll.currencyID)
-      local currencyIcon = data.iconFileID
+      local currencyIcon = CurrencyModule.OverrideTexture[roll.currencyID] or data.iconFileID
       local str = "\124T" .. currencyIcon .. ":0\124t "
       if roll.money then
         str = str .. roll.money
@@ -2373,7 +2376,8 @@ hoverTooltip.ShowCurrencySummary = function (cell, arg, ...)
   local idx = arg
   if not idx then return end
   local data = C_CurrencyInfo.GetCurrencyInfo(idx)
-  local name, tex = data.name, data.iconFileID
+  local name = CurrencyModule.OverrideName[idx] or data.name
+  local tex = CurrencyModule.OverrideTexture[idx] or data.iconFileID
   tex = " \124T"..tex..":0\124t"
   local itemFlag, itemIcon
   if SI.specialCurrency[idx] and SI.specialCurrency[idx].relatedItem then
@@ -4600,7 +4604,8 @@ function SI:ShowTooltip(anchorframe)
           end
           if not show and (gotThisWeek or gotSome) and columns[toon .. 1] then
             local data = C_CurrencyInfo.GetCurrencyInfo(idx)
-            local name, tex = data.name, data.iconFileID
+            local name = CurrencyModule.OverrideName[idx] or data.name
+            local tex = CurrencyModule.OverrideTexture[idx] or data.iconFileID
             show = format(" \124T%s:0\124t%s", tex, name)
           end
         end

--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -625,7 +625,7 @@ SI.transInstance = {
   [1530] = 1353, -- The Nighthold: issue #186 frFR
   [585] = 1154, -- Magisters' Terrace: issue #293 frFR
   [2235] = 1911, -- Caverns of Time - Anniversary: issue #315 (fake LFDID used by Escape from Tol Dagor)
-  [725] = 1148, -- The Stonecore: issue #328 frFR
+  [725] = 320, -- The Stonecore: issue #328 frFR
   [2515] = 2335, -- The Azure Vault: issue #630 deDE
   [550] = 193, -- Tempest Keep: issue #612 ruRU
 }

--- a/SavedInstances/Modules/Currency.lua
+++ b/SavedInstances/Modules/Currency.lua
@@ -91,6 +91,11 @@ local currency = {
   2122, -- Storm Sigil
   2123, -- Bloody Tokens
   2245, -- Flightstones
+  2409, -- Whelpling Crest Fragment Tracker [DNT]
+  2410, -- Drake Crest Fragment Tracker [DNT]
+  2411, -- Wyrm Crest Fragment Tracker [DNT]
+  2412, -- Aspect Crest Fragment Tracker [DNT]
+  2413, -- 10.1 Professions - Personal Tracker - S2 Spark Drops (Hidden)
   2533, -- Renascent Shadowflame
 }
 SI.currency = currency
@@ -170,6 +175,18 @@ for _, tbl in pairs(specialCurrency) do
     end
   end
 end
+
+Module.OverrideName = {
+  [2409] = L["Loot Whelpling Crest Fragment"], -- Whelpling Crest Fragment Tracker [DNT]
+  [2410] = L["Loot Drake Crest Fragment"], -- Drake Crest Fragment Tracker [DNT]
+  [2411] = L["Loot Wyrm Crest Fragment"], -- Wyrm Crest Fragment Tracker [DNT]
+  [2412] = L["Loot Aspect Crest Fragment"], -- Aspect Crest Fragment Tracker [DNT]
+  [2413] = L["Loot Spark of Shadowflame"], -- 10.1 Professions - Personal Tracker - S2 Spark Drops (Hidden)
+}
+
+Module.OverrideTexture = {
+  [2413] = 5088829, -- 10.1 Professions - Personal Tracker - S2 Spark Drops (Hidden)
+}
 
 function Module:OnEnable()
   self:RegisterEvent("PLAYER_MONEY", "UpdateCurrency")

--- a/SavedInstances/Modules/Currency.lua
+++ b/SavedInstances/Modules/Currency.lua
@@ -90,7 +90,6 @@ local currency = {
   2118, -- Elemental Overflow
   2122, -- Storm Sigil
   2123, -- Bloody Tokens
-  2167, -- Catalyst Charges
   2245, -- Flightstones
   2533, -- Renascent Shadowflame
 }
@@ -108,7 +107,6 @@ end)
 SI.currencySorted = currencySorted
 
 local hiddenCurrency = {
-  [2167] = true, -- Catalyst Charges
 }
 
 local specialCurrency = {
@@ -228,9 +226,6 @@ function Module:UpdateCurrency()
           ci.covenant = ci.covenant or {}
           ci.covenant[covenantID] = ci.amount
         end
-      elseif idx == 2167 then -- Catalyst Charges
-        ci.weeklyMax = nil
-        ci.earnedThisWeek = nil
       end
       -- don't store useless info
       if ci.weeklyMax == 0 then ci.weeklyMax = nil end

--- a/SavedInstances/Modules/MythicPlus.lua
+++ b/SavedInstances/Modules/MythicPlus.lua
@@ -82,6 +82,10 @@ local KeystoneAbbrev = {
   [400] = L["TNO"],   -- The Nokhud Offensive
   [401] = L["TAV"],   -- The Azure Vault
   [402] = L["AA"],    -- Algeth'ar Academy
+  [403] = L["ULD"],   -- Uldaman: Legacy of Tyr
+  [404] = L["NELT"],  -- Neltharus
+  [405] = L["BH"],    -- Brackenhide Hollow
+  [406] = L["HOI"],   -- Halls of Infusion
 }
 SI.KeystoneAbbrev = KeystoneAbbrev
 

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -688,6 +688,9 @@ Module.TrackedQuest = {
       72374, -- Aiding the Accord: Dragonbane Keep
       72375, -- Aiding the Accord: The Isles Call
       75259, -- Aiding the Accord: Zskera Vault
+      75859, -- Aiding the Accord: Sniffenseeking
+      75860, -- Aiding the Accord: Researchers Under Fire
+      75861, -- Aiding the Accord: Suffusion Camp
     },
   },
   {
@@ -780,7 +783,19 @@ Module.TrackedQuest = {
       72648, -- The Azure Span
       72649, -- Thaldraszus
     },
-  }
+  },
+  {
+    name = L["A Worthy Ally: Loamm Niffen"],
+    weekly = true,
+    quest = 75665,
+    relatedQuest = {75665},
+  },
+  {
+    name = L["Fighting is Its Own Reward"],
+    weekly = true,
+    quest = 76122,
+    relatedQuest = {76122},
+  },
 }
 
 function Module:OnEnable()

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -788,6 +788,7 @@ Module.TrackedQuest = {
     name = L["A Worthy Ally: Loamm Niffen"],
     weekly = true,
     quest = 75665,
+    resetFunc = KeepProgress,
     relatedQuest = {75665},
   },
   {

--- a/SavedInstances/Modules/Quest.lua
+++ b/SavedInstances/Modules/Quest.lua
@@ -355,6 +355,9 @@ local QuestExceptions = {
   [72374] = "Weekly", -- Aiding the Accord: Dragonbane Keep
   [72375] = "Weekly", -- Aiding the Accord: The Isles Call
   [75259] = "Weekly", -- Aiding the Accord: Zskera Vault
+  [75859] = "Weekly", -- Aiding the Accord: Sniffenseeking
+  [75860] = "Weekly", -- Aiding the Accord: Researchers Under Fire
+  [75861] = "Weekly", -- Aiding the Accord: Suffusion Camp
   -- Fishing Weeklies
   [70199] = "Weekly", -- Catch and Release: Scalebelly Mackerel
   [70200] = "Weekly", -- Catch and Release: Thousandbite Piranha
@@ -449,6 +452,9 @@ local QuestExceptions = {
   [72686] = "Weekly", -- Storm Surge
   -- Revival Catalyst
   [72528] = "AccountWeekly", -- Revival Catalyst
+  -- Other Weeklies
+  [75665] = "Weekly", -- A Worthy Ally: Loamm Niffen
+  [76122] = "Weekly", -- Fighting is Its Own Reward
 
   -- General
   -- Darkmoon Faire

--- a/SavedInstances/Modules/Quest.lua
+++ b/SavedInstances/Modules/Quest.lua
@@ -473,9 +473,9 @@ local QuestExceptions = {
 
   -- Weekend Event
   [72728] = "Weekly", -- The World Awaits - World Quests
-  -- [62632] = "Weekly", -- A Burning Path Through Time - TBC Timewalking
-  -- [62633] = "Weekly", -- A Frozen Path Through Time - WLK Timewalking
-  -- [62634] = "Weekly", -- A Shattered Path Through Time - CTM Timewalking
+  [72727] = "Weekly", -- A Burning Path Through Time - TBC Timewalking
+  [72726] = "Weekly", -- A Frozen Path Through Time - WLK Timewalking
+  [72810] = "Weekly", -- A Shattered Path Through Time - CTM Timewalking
   [72725] = "Weekly", -- A Shrouded Path Through Time - MOP Timewalking
   [72724] = "Weekly", -- A Savage Path Through Time - WOD Timewalking
   [72719] = "Weekly", -- A Fel Path Through Time - LEG Timewalking


### PR DESCRIPTION
## Feature

* Drop Catalyst Charges
* Update Timewalking quest id
* Tweak The Stonecore in frFR to the real instances ID
* Add new weeklies
  * 3x Aiding the Accord (closes #734 )
  * A Worthy Ally: Loamm Niffen
  * Fighting is Its Own Reward
* Add missing DF Mythic+ Dungeons
* Add hidden currency to track crest and spark
  * also add a way to override currency name and texture