### PR TITLE
Add 'Time Rift' as trackable progress

### DIFF
--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -688,6 +688,19 @@ local presets = {
     persists = false,
     fullObjective = false,
   },
+  -- Time Rift
+  ['df-time-rift'] = {
+    type = 'any',
+    expansion = 9,
+    index = 16,
+    name = L["Time Rift"],
+    questID = {
+      77836
+    },
+    reset = 'weekly',
+    persists = false,
+    fullObjective = false
+  },
 }
 
 ---update the progress of quest to the store

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -694,9 +694,7 @@ local presets = {
     expansion = 9,
     index = 16,
     name = L["Time Rift"],
-    questID = {
-      77836
-    },
+    questID = 77836,
     reset = 'weekly',
     persists = false,
     fullObjective = false

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -690,7 +690,7 @@ local presets = {
   },
   -- Time Rift
   ['df-time-rift'] = {
-    type = 'any',
+    type = 'single',
     expansion = 9,
     index = 16,
     name = L["Time Rift"],


### PR DESCRIPTION
Adds quest 77836 (Time Rift) as stand-alone line in the progress view.

Not sure if more than this is needed.