### PR TITLE
Add 'Shaping the Dreamsurge' as trackable progress

### DIFF
--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -688,6 +688,19 @@ local presets = {
     persists = false,
     fullObjective = false,
   },
+  -- Dreamsurge
+  ['df-dreamsurge'] = {
+    type = 'any',
+    expansion = 9,
+    index = 17,
+    name = L["Shaping the Dreamsurge"],
+    questID = {
+      77251
+    },
+    reset = 'weekly',
+    persists = false,
+    fullObjective = false
+  }
 }
 
 ---update the progress of quest to the store

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -690,7 +690,7 @@ local presets = {
   },
   -- Dreamsurge
   ['df-dreamsurge'] = {
-    type = 'any',
+    type = 'single',
     expansion = 9,
     index = 17,
     name = L["Shaping the Dreamsurge"],

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -694,9 +694,7 @@ local presets = {
     expansion = 9,
     index = 17,
     name = L["Shaping the Dreamsurge"],
-    questID = {
-      77251
-    },
+    questID = 77251,
     reset = 'weekly',
     persists = false,
     fullObjective = false


### PR DESCRIPTION
Adds quest 77251 (Shaping the Dreamsurge) as stand-alone line in the progress view.

Not sure if more than this is needed.