### PR TITLE
Updates Patch 10.2 Progress & Quest

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -235,6 +235,7 @@ globals = {
 	"BuyReagentBank",
 	"BuyTrainerService",
 	"BuybackItem",
+	"C_AddOns",
 	"C_AdventureJournal",
 	"C_AdventureJournal.ActivateEntry",
 	"C_AdventureJournal.CanBeShown",

--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -3856,7 +3856,7 @@ function SI:ShowTooltip(anchorframe)
         if t.MythicKeyBest.lastCompletedIndex then
           for index = 1, t.MythicKeyBest.lastCompletedIndex do
             if t.MythicKeyBest[index] then
-              keydesc = keydesc .. (index > 1 and " / " or "") .. t.MythicKeyBest[index]
+              keydesc = keydesc .. (index > 1 and "||" or "") .. t.MythicKeyBest[index]
             end
           end
         end

--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -457,7 +457,7 @@ SI.defaultDB = {
 --   hooksecurefunc(SavedInstances,"SkinFrame",function(self,frame,name) frame:SetWhatever() end)
 function SI:SkinFrame(frame, name)
   -- default behavior (ticket 81)
-  if IsAddOnLoaded("ElvUI") or IsAddOnLoaded("Tukui") then
+  if C_AddOns.IsAddOnLoaded("ElvUI") or C_AddOns.IsAddOnLoaded("Tukui") then
     if frame.StripTextures then
       frame:StripTextures()
     end
@@ -2420,7 +2420,7 @@ function SI:toonInit()
 end
 
 function SI:OnInitialize()
-  local versionString = GetAddOnMetadata("SavedInstances", "version")
+  local versionString = C_AddOns.GetAddOnMetadata("SavedInstances", "version")
   --@debug@
   if versionString == "@project-version@" then
     versionString = "Dev"
@@ -3237,8 +3237,8 @@ SI.cpairs = cpairs
 local function OpenWeeklyRewards()
   if _G.WeeklyRewardsFrame and _G.WeeklyRewardsFrame:IsVisible() then return end
 
-  if not IsAddOnLoaded('Blizzard_WeeklyRewards') then
-    LoadAddOn('Blizzard_WeeklyRewards')
+  if not C_AddOns.IsAddOnLoaded('Blizzard_WeeklyRewards') then
+    C_AddOns.LoadAddOn('Blizzard_WeeklyRewards')
   end
   _G.WeeklyRewardsFrame:Show()
 end

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -103,7 +103,7 @@ local presets = {
       local text
       for index = 1, #store do
         if store[index] then
-          text = (index > 1 and (text .. " / ") or "") .. (entry.difficultyNames[store[index]] or GetDifficultyInfo(store[index]))
+          text = (index > 1 and (text .. "||") or "") .. (entry.difficultyNames[store[index]] or GetDifficultyInfo(store[index]))
         end
       end
       if store.rewardWaiting then
@@ -376,7 +376,7 @@ local presets = {
         if not text then
           text = store[factionID] and store[factionID][1] or '0'
         else
-          text = text .. ' / ' .. (store[factionID] and store[factionID][1] or '0')
+          text = text .. "||" .. (store[factionID] and store[factionID][1] or '0')
         end
       end
 
@@ -385,7 +385,7 @@ local presets = {
           if not text then
             text = store[factionID] and store[factionID][1] or '0'
           else
-            text = text .. ' / ' .. (store[factionID] and store[factionID][1] or '0')
+            text = text .. "||" .. (store[factionID] and store[factionID][1] or '0')
           end
         end
       end

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -725,6 +725,43 @@ local presets = {
     persists = true,
     fullObjective = false,
   },
+  -- The Superbloom
+  ['df-the-superbloom'] = {
+    type = 'single',
+    expansion = 9,
+    index = 19,
+    name = L["The Superbloom"],
+    questID = 78319,
+    reset = 'weekly',
+    persists = true,
+    fullObjective = false,
+  },
+  -- Blooming Dreamseeds
+  ['df-blooming-dreamseeds'] = {
+    type = 'single',
+    expansion = 9,
+    index = 20,
+    name = L["Blooming Dreamseeds"],
+    questID = 78821,
+    reset = 'weekly',
+    persists = true,
+    fullObjective = false,
+  },
+  -- Shipment of Goods
+  ['df-shipment-of-goods'] = {
+    type = 'list',
+    expansion = 9,
+    index = 21,
+    name = L["Shipment of Goods"],
+    questID = {
+      78427, -- Great Crates!
+      78428, -- Crate of the Art
+    },
+    reset = 'weekly',
+    persists = false,
+    progress = true,
+    onlyOnOrCompleted = false,
+  },
 }
 
 ---update the progress of quest to the store

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -427,6 +427,7 @@ local presets = {
     end,
     -- addition info
     factionIDs = {
+      2574, -- Dream Wardens
       2564, -- Loamm Niffen
       2507, -- Dragonscale Expedition
       2503, -- Maruuk Centaur

--- a/SavedInstances/Modules/Quest.lua
+++ b/SavedInstances/Modules/Quest.lua
@@ -472,7 +472,11 @@ local QuestExceptions = {
   [75665] = "Weekly", -- A Worthy Ally: Loamm Niffen
   [76122] = "Weekly", -- Fighting is Its Own Reward
   [77236] = "AccountWeekly", -- When Time Needs Mending
+  [78319] = "Weekly", -- The Superbloom
+  [78427] = "Weekly", -- Great Crates!
+  [78428] = "Weekly", -- Crate of the Art
   [78444] = "Weekly", -- A Worthy Ally: Dream Wardens
+  [78821] = "Weekly", -- Blooming Dreamseeds
 
   -- General
   -- Darkmoon Faire


### PR DESCRIPTION
### Features

* Add Dream Wardens to Dragonflight Renown (mostly for order)
* Add 4 more weeklies in Patch 10.2

### Misc

* `IsAddOnLoaded`, `GetAddOnMetadata `, `IsAddOnLoaded ` are deprecated
* use "|" instand of " / " to save space