### PR TITLE
feat: store paragon prog for rep progress if paragon

### DIFF
--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -364,6 +364,11 @@ local presets = {
       local majorFactionIDs = C_MajorFactions.GetMajorFactionIDs(LE_EXPANSION_DRAGONFLIGHT)
       for _, factionID in ipairs(majorFactionIDs) do
         local data = C_MajorFactions.GetMajorFactionData(factionID)
+        local currentRepValue, threshold = C_Reputation.GetFactionParagonInfo(factionID)
+        if currentRepValue and threshold then
+          data.renownReputationEarned = currentRepValue % threshold
+          data.renownLevelThreshold = threshold
+        end
         store[factionID] = data and {data.renownLevel, data.renownReputationEarned, data.renownLevelThreshold}
       end
     end,


### PR DESCRIPTION
This change stores Paragon reputation progress into the df-renown reputation progress table if the player is into the Paragon levels of the renown. It my proposal to solve #803. Lots more context for the motivation for this change in that issue.

The `C_Reputation.GetFactionParagonInfo` API returns nothing if the reputation isn't at Paragon yet, hence the if check on the two values coming from it. The `data` variable being mutated is locally scoped to that for loop, so there shouldn't be any side effects. Both the current rep and threshold values are being overwritten, so that the tooltip reflects the player's progress towards the paragon cache.

Here's what the tooltip looks like with this change for a character that is into Paragon levels with Loamm, DE, MC, IT, and Vald:
![renown-fix-example](https://github.com/SavedInstances/SavedInstances/assets/1039832/5560c710-fc1c-4843-a975-4d2ccf2fa500)

Here's another character, with just Loamm and Iskarr into Paragon:
![renown-fix-example-2](https://github.com/SavedInstances/SavedInstances/assets/1039832/4f82aed5-43ae-4da7-9bf7-50f085f2e683)

Note that the values for current rep and threshold are unchanged if not Paragon.

**Additional Thoughts**
- I looked at the `Paragon.lua` module as a potential place to make this change, but opted to build it into the df-renown tooltip as it made much more sense to see Paragon info in it than the value currently displayed in there.
- If someone has a Paragon cache waiting (Nisko from the screenshot above happens to have one pending with Valdrakken), the modulo operator will mean the display has "rolled over" and is showing progress towards the next one. The separate display already defined by `Paragon.lua` would let the player know they have a cache ready. Maybe this is weird?
