### PR TITLE
Quick Bug Fix and Features

### DIFF
--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -4222,7 +4222,7 @@ function SI:ShowTooltip(anchorframe)
               if (ci.weeklyMax or 0) > 0 then
                 str = earned.." ("..CurrencyColor(ci.earnedThisWeek,ci.weeklyMax)..weeklymax..")"
               elseif (ci.amount or 0) > 0 or (ci.totalEarned or 0) > 0 then
-                str = CurrencyColor(ci.amount,ci.totalMax)..totalmax
+                str = CurrencyColor(ci.amount, ci.totalEarned or ci.totalMax)..totalmax
               end
               if SI.specialCurrency[idx] and SI.specialCurrency[idx].relatedItem then
                 if SI.specialCurrency[idx].relatedItem.holdingMax then

--- a/SavedInstances/Modules/MythicPlus.lua
+++ b/SavedInstances/Modules/MythicPlus.lua
@@ -130,7 +130,7 @@ do
     end
 
     local color = C_ChallengeMode_GetKeystoneLevelRarityColor(level)
-    colorCache[level] = color:GenerateHexColor()
+    colorCache[level] = color and color:GenerateHexColor() or 'ffffffff'
     return colorCache[level]
   end
 

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -622,8 +622,9 @@ local presets = {
       72647, -- Ohn'ahran Plains
       72648, -- The Azure Span
       72649, -- Thaldraszus
-	  75305, -- Zaralek Cavern
-	  78097, -- Emerald Dream
+      74871, -- The Forbidden Reach
+      75305, -- Zaralek Cavern
+      78097, -- Emerald Dream
     },
     reset = 'weekly',
     persists = false,


### PR DESCRIPTION
* Quick Fix: Blizzard breaks `C_ChallengeMode.GetKeystoneLevelRarityColor` in recent update
* Feature: add Sparks of Life: The Forbidden Reach
* Feature: prefer total earned (like season earn cap) than total cap on currency color