### PR TITLE
Add Radiant Echoes preset

### DIFF
--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -697,6 +697,21 @@ local presets = {
     persists = true,
     fullObjective = false,
   },
+  ["tww-radiant-echoes"] = {
+    type = "list",
+    expansion = 10,
+    index = 23,
+    name = L["Radiant Echoes"],
+    questID = {
+      82676, -- Broken Masquerade
+      78938, -- Champion of the Waterlords
+      82689, -- Only Darkness
+    },
+    reset = "weekly",
+    persists = false,
+    progress = true,
+    onlyOnOrCompleted = false,
+  },
 }
 
 ---update the progress of quest to the store

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -697,14 +697,15 @@ local presets = {
     persists = true,
     fullObjective = false,
   },
+  -- Radiant Echoes Weeklies
   ["tww-radiant-echoes"] = {
     type = "list",
     expansion = 10,
-    index = 23,
+    index = 1,
     name = L["Radiant Echoes"],
     questID = {
-      82676, -- Broken Masquerade
       78938, -- Champion of the Waterlords
+      82676, -- Broken Masquerade
       82689, -- Only Darkness
     },
     reset = "weekly",


### PR DESCRIPTION
Adds a preset for the Radiant Echoes TWW Pre-patch weeklies.

![image](https://github.com/user-attachments/assets/77577b36-1150-403e-9094-e3a675518a83)
