### PR TITLE
Add warband bank money

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -53,6 +53,7 @@ globals = {
 	"C_Calendar",
 	"C_MythicPlus",
 	"C_Spell",
+	"C_Bank",
 	"CooldownFrame_Set",
 	"DEFAULT_CHAT_FRAME",
 	"GameTooltip_Hide",

--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -2100,6 +2100,7 @@ hoverTooltip.ShowAccountSummary = function(cell, arg, ...)
   local ttime = 0
   local ttoons = 0
   local tmaxtoons = 0
+  local warbandMoney = C_Bank.FetchDepositedMoney(Enum.BankType.Account)
   local r = {}
   for toon, t in pairs(SI.db.Toons) do -- deliberately include ALL toons
     local realm = toon:match(" %- (.+)$")
@@ -2135,6 +2136,8 @@ hoverTooltip.ShowAccountSummary = function(cell, arg, ...)
   end
 
   -- history information
+  indicatortip:AddLine("")
+  indicatortip:AddLine(L["Warband Money"], SI:formatNumber(warbandMoney, true))
   indicatortip:AddLine("")
   SI:HistoryUpdate()
   local tmp = {}


### PR DESCRIPTION
#861 

Add warband bank money tracking

![savedinstances-warband-money-tooltip](https://github.com/user-attachments/assets/8c6f1960-b3f6-436a-b20c-c816d174311c)
