### PR TITLE
Update Tooltip, Progress, Quest, Trade Skill

### DIFF
--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -4405,7 +4405,11 @@ function SI:ShowTooltip(anchorframe)
                 weeklymax = "/" .. SI:formatNumber(ci.weeklyMax)
               end
               if (ci.totalMax or 0) > 0 then
-                totalmax = "/" .. SI:formatNumber(ci.totalMax)
+                if (ci.totalEarned or 0) > 0 then
+                  totalmax = "/" .. SI:formatNumber(ci.totalMax - ci.totalEarned + ci.amount)
+                else
+                  totalmax = "/" .. SI:formatNumber(ci.totalMax)
+                end
               end
             end
             if SI.db.Tooltip.CurrencyEarned or showall then

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -982,11 +982,14 @@ local presets = {
     index = 13,
     name = L["Biergoth Dungeon Quest"],
     questID = {
+      83432, -- The Rookery
+      83436, -- Cinderbrew Meadery
       83443, -- Darkflame Cleft
       83457, -- The Stonevault
       83458, -- Priory of the Sacred Flame
       83459, -- The Dawnbreaker
       83465, -- Ara-Kara, City of Echoes
+      83469, -- City of Threads
     },
     reset = "weekly",
     persists = false,

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -346,11 +346,66 @@ local presets = {
     persists = false,
     fullObjective = false,
   },
+  -- Replenish the Reservoir
+  ["sl-replenish-the-reservoir"] = {
+    type = "any",
+    expansion = 8,
+    name = L["Replenish the Reservoir"],
+    persists = true,
+    index = 1,
+    questID = {
+      61981, -- Venthyr
+      61982, -- Kyrian
+      61983, -- Necrolord
+      61984, -- Night Fae
+    },
+    fullObjective = true,
+    reset = "weekly",
+  },
+  -- Return Lost Souls
+  ["sl-return-lost-souls"] = {
+    type = "any",
+    expansion = 8,
+    name = L["Return Lost Souls"],
+    persists = true,
+    index = 2,
+    questID = {
+      61331,
+      61332,
+      61333,
+      61334,
+      62858,
+      62859,
+      62860,
+      62861,
+      62862,
+      62863,
+      62864,
+      62865,
+      62866,
+      62867,
+      62868,
+      62869,
+    },
+    fullObjective = true,
+    reset = "weekly",
+  },
+  -- Shaping Fate
+  ["sl-shaping-fate"] = {
+    type = "single",
+    expansion = 8,
+    name = L["Shaping Fate"],
+    persists = true,
+    index = 3,
+    questID = 63949,
+    fullObjective = true,
+    reset = "weekly",
+  },
   -- Covenant Assaults
   ["sl-covenant-assault"] = {
     type = "any",
     expansion = 8,
-    index = 1,
+    index = 4,
     name = L["Covenant Assaults"],
     questID = {
       63823, -- Night Fae Assault
@@ -366,7 +421,7 @@ local presets = {
   ["sl-patterns-within-patterns"] = {
     type = "single",
     expansion = 8,
-    index = 2,
+    index = 5,
     name = L["Patterns Within Patterns"],
     questID = 66042,
     reset = "weekly",

--- a/SavedInstances/Modules/Quest.lua
+++ b/SavedInstances/Modules/Quest.lua
@@ -148,6 +148,9 @@ local _specialQuests = {
   [66388] = { name = L["Disturbed Dirt / Expedition Scout's Pack"] .. " - " .. C_Spell_GetSpellName(25229) }, -- Jewelcrafting
   [66389] = { name = L["Disturbed Dirt / Expedition Scout's Pack"] .. " - " .. C_Spell_GetSpellName(25229) }, -- Jewelcrafting
 
+  -- TWW
+  [81090] = { name = L["Alchemy Thaumaturgy"] }, -- Alchemy Thaumaturgy
+
   -- Old Vanilla Bosses during Anniversary Event
   [47461] = { daily = true, name = L["Lord Kazzak"] }, -- Lord Kazzak
   [47462] = { daily = true, name = L["Azuregos"] }, -- Azuregos

--- a/SavedInstances/Modules/TradeSkill.lua
+++ b/SavedInstances/Modules/TradeSkill.lua
@@ -283,6 +283,9 @@ local tradeSpells = {
   -- Transporter
   [23453] = "item", -- Ultrasafe Transporter: Gadgetzhan
   [36941] = "item", -- Ultrasafe Transporter: Toshley's Station
+  -- Skinning
+  [382134] = "item", -- Elusive Creature Bait
+  [442680] = "item", -- Elusive Creature Lure
 }
 
 local itemCDs = { -- [spellID] = itemID
@@ -306,6 +309,9 @@ local itemCDs = { -- [spellID] = itemID
   -- Transporter
   [23453] = 18986, -- Ultrasafe Transporter: Gadgetzhan
   [36941] = 30544, -- Ultrasafe Transporter: Toshley's Station
+  -- Skinning
+  [382134] = 193906, -- Elusive Creature Bait
+  [442680] = 219007, -- Elusive Creature Lure
 }
 
 local categoryNames = {


### PR DESCRIPTION
### Feature

* Progress: update Biergoth Dungeon Quest list
* Progress: add Shadowlands weekly quests
* Trade Skill: add Skinning Bait & Lure
* Quest: add Alchemy Thaumaturgy daily first act
* Tooltip: show earn-capped currency's total change from total to earnable cap