### PR TITLE
Update Progress & Random Daily Reward

### DIFF
--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -1328,13 +1328,19 @@ function SI:UpdateToonData()
     if (i.Holiday and SI.activeHolidays[instance]) or (i.Random and not i.Holiday) then
       local id = i.LFDID
       GetLFGDungeonInfo(id) -- forces update
+      local _, isAvailableForPlayer, hideIfNotJoinable = IsLFGDungeonJoinable(id)
       local donetoday, money = GetLFGDungeonRewards(id)
+      if not isAvailableForPlayer and hideIfNotJoinable then
+        -- ignore hidden LFG donetoday
+        donetoday = false
+      end
       if
         donetoday
         and i.Random
         and (
-          id == 301 -- Cata heroic
-          or id == 434 -- Hour of Twilight
+          id == 301 -- Random Cataclysm Heroic
+          or id == 434 -- Random Hour of Twilight Heroic
+          or id == 2714 -- The Codex of Chromie
         )
       then -- donetoday flag is falsely set for some level/dungeon combos where no daily incentive is available
         donetoday = false

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -910,15 +910,12 @@ local presets = {
     name = L["The Call of the Worldsoul"],
     questID = {
       -- https://wago.tools/db2/QuestLineXQuest?filter[QuestLineID]=5572&page=1&sort[OrderIndex]=asc
-      82458, -- Worldsoul: Renown
       82482, -- Worldsoul: Snuffling
       82516, -- Worldsoul: Forging a Pact
       82483, -- Worldsoul: Spreading the Light
       82453, -- Worldsoul: Encore!
       82489, -- Worldsoul: The Dawnbreaker
       82659, -- Worldsoul: Nerub-ar Palace
-      82678, -- Archives: The First Disc
-      82679, -- Archives: Seeking History
       82490, -- Worldsoul: Priory of the Sacred Flame
       82491, -- Worldsoul: Ara-Kara, City of Echoes
       82492, -- Worldsoul: City of Threads
@@ -941,19 +938,43 @@ local presets = {
       82510, -- Worldsoul: Nerub-ar Palace
       82511, -- Worldsoul: Awakening Machine
       82512, -- Worldsoul: World Boss
-      82513, --
-      82514, --
-      82515, --
       82488, -- Worldsoul: Darkflame Cleft
       82487, -- Worldsoul: The Stonevault
       82486, -- Worldsoul: The Rookery
       82485, -- Worldsoul: Cinderbrew Meadery
-      82484, --
       82452, -- Worldsoul: World Quests
       82495, -- Worldsoul: Cinderbrew Meadery
-      82706, -- Delves: Khaz Algar Research
-      82707, -- Delves: Earthen Defense
+    },
+    reset = "weekly",
+    persists = true,
+    fullObjective = false,
+  },
+  -- The Call of the Worldsoul
+  ["tww-archives"] = {
+    type = "any",
+    expansion = 10,
+    index = 7.1,
+    name = L["Archives"],
+    questID = {
+      -- https://wago.tools/db2/QuestLineXQuest?filter[QuestLineID]=5572&page=1&sort[OrderIndex]=asc
+      82678, -- Archives: The First Disc
+      82679, -- Archives: Seeking History
+    },
+    reset = "weekly",
+    persists = true,
+    fullObjective = false,
+  },
+  -- The Call of the Worldsoul
+  ["tww-delves"] = {
+    type = "any",
+    expansion = 10,
+    index = 7.2,
+    name = L["Delves"],
+    questID = {
+      -- https://wago.tools/db2/QuestLineXQuest?filter[QuestLineID]=5572&page=1&sort[OrderIndex]=asc
       82708, -- Delves: Nerubian Menace
+      82707, -- Delves: Earthen Defense
+      82706, -- Delves: Khaz Algar Research
       82709, -- Delves: Percussive Archaeology
       82710, -- Delves: Empire-ical Exploration
       82711, -- Delves: Lost and Found

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -1139,6 +1139,17 @@ local presets = {
     persists = true,
     fullObjective = false,
   },
+  -- Anniversary Restored Coffer Key
+  ["tww-anniversary-restored-coffer-key"] = {
+    type = "single",
+    expansion = 10,
+    index = 17,
+    name = L["Anniversary Restored Coffer Key"],
+    questID = 86202,
+    reset = "weekly",
+    persists = true,
+    fullObjective = false,
+  },
 }
 
 ---update the progress of quest to the store


### PR DESCRIPTION
* Fix meta weekly quests contains Worldsoul, Archives, Delves that is actually three types of meta quest, whose complete status will mess up with each other.
* Fix hidden timewalking LFG queue and The Codex of Chromie are flagged with daily reward claimed.
* Track Anniversary Restored Coffer Key, closes #915 , closes #916 