### PR TITLE
Update Coffer Key Shard for 11.1

### DIFF
--- a/SavedInstances/Modules/Currency.lua
+++ b/SavedInstances/Modules/Currency.lua
@@ -218,7 +218,7 @@ local specialCurrency = {
   },
   [3028] = { -- Restored Coffer Key
     relatedItem = {
-      id = 229899, -- Coffer Key Shard
+      id = 236096, -- Coffer Key Shard
     },
   },
 }


### PR DESCRIPTION
After S2 update with 1 shard in inventory. Was showing 0 before. Looks like the currency is the same but a new item ID for the shards.

![image](https://github.com/user-attachments/assets/04224d24-98dc-4d24-bacb-7bdb4dc43e1f)
