### PR TITLE
Fixed Liberation of Undermine tracked as dungeon

### DIFF
--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -1244,7 +1244,7 @@ function SI:UpdateInstance(id)
   if recLevel > 0 and recLevel < instance.RecLevel then
     instance.RecLevel = recLevel
   end -- favor non-heroic RecLevel
-  instance.Raid = (maxPlayers > 5 or (maxPlayers == 0 and typeID == 2))
+  instance.Raid = (maxPlayers > 5 or ((maxPlayers == 0 or maxPlayers == 5) and typeID == 2))
   if typeID == TYPEID_RANDOM_DUNGEON then
     instance.Random = true
   end


### PR DESCRIPTION
Fixes #950

Not sure why this is the case but there was already a special case in there. Does this even need the maxPlayers check? 

![image](https://github.com/user-attachments/assets/b5af505f-e1ca-45b4-9b43-4c955945c908)
