### PR TITLE
Always display amount if there is a relatedItemCount

### DIFF
--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -4254,10 +4254,10 @@ function SI:ShowTooltip(anchorframe)
               earned = CurrencyColor(ci.amount, ci.totalMax) .. totalmax
             end
             local str
-            if (ci.amount or 0) > 0 or (ci.earnedThisWeek or 0) > 0 or (ci.totalEarned or 0) > 0 then
+            if (ci.amount or 0) > 0 or (ci.earnedThisWeek or 0) > 0 or (ci.totalEarned or 0) > 0 or (ci.relatedItemCount or 0) > 0 then
               if (ci.weeklyMax or 0) > 0 then
                 str = earned .. " (" .. CurrencyColor(ci.earnedThisWeek, ci.weeklyMax) .. weeklymax .. ")"
-              elseif (ci.amount or 0) > 0 or (ci.totalEarned or 0) > 0 then
+              elseif (ci.amount or 0) > 0 or (ci.totalEarned or 0) > 0 or (ci.relatedItemCount or 0) > 0 then
                 str = CurrencyColor(ci.amount, ci.totalMax, ci.totalEarned) .. totalmax
               end
               if SI.specialCurrency[idx] and SI.specialCurrency[idx].relatedItem then


### PR DESCRIPTION
Fixes #953 by displaying a 0 and the relatedItemCount if there is a relatedItemCount

![image](https://github.com/user-attachments/assets/9f29abbf-ebdf-40ff-b989-68712969c3bb)
