### PR TITLE
Fixes mythic LUA errors in patch 11.1.5

### DIFF
--- a/SavedInstances/Modules/MythicPlus.lua
+++ b/SavedInstances/Modules/MythicPlus.lua
@@ -11,6 +11,8 @@ local C_ChallengeMode_GetMapUIInfo = C_ChallengeMode.GetMapUIInfo
 local C_Container_GetContainerItemID = C_Container.GetContainerItemID
 local C_Container_GetContainerItemLink = C_Container.GetContainerItemLink
 local C_Container_GetContainerNumSlots = C_Container.GetContainerNumSlots
+local C_MythicPlus_GetOwnedKeystoneChallengeMapID = C_MythicPlus.GetOwnedKeystoneChallengeMapID
+local C_MythicPlus_GetOwnedKeystoneLevel = C_MythicPlus.GetOwnedKeystoneLevel
 local C_MythicPlus_GetRunHistory = C_MythicPlus.GetRunHistory
 local C_MythicPlus_RequestMapInfo = C_MythicPlus.RequestMapInfo
 local C_MythicPlus_GetRewardLevelFromKeystoneLevel = C_MythicPlus.GetRewardLevelFromKeystoneLevel
@@ -162,10 +164,8 @@ do
   end
 
   function Module:ProcessKey(itemLink, targetTable)
-    local _, _, mapID, mapLevel = strsplit(":", itemLink)
-    mapID = tonumber(mapID)
-    mapLevel = tonumber(mapLevel)
-
+    local mapID = C_MythicPlus_GetOwnedKeystoneChallengeMapID()
+    local mapLevel = C_MythicPlus_GetOwnedKeystoneLevel()
     targetTable.link = itemLink
     targetTable.mapID = mapID
     targetTable.level = mapLevel


### PR DESCRIPTION
Fixes #960

It looks like there was a new field possibly added and the split failed here. 

One fix was to add an additional field to the split, but doing some research calling these method _seems_ like it's more future proof over the split. 

Alternative fix is

`    local _, _, _, mapID, mapLevel = strsplit(":", itemLink)`

Had to do a "Reset Characters" or log-in to the broken characters after applying this. 