### PR TITLE
LUA errors in patch 11.1.5

### DIFF
--- a/SavedInstances/Modules/MythicPlus.lua
+++ b/SavedInstances/Modules/MythicPlus.lua
@@ -162,7 +162,7 @@ do
   end
 
   function Module:ProcessKey(itemLink, targetTable)
-    local _, _, mapID, mapLevel = strsplit(":", itemLink)
+    local _, _, _, mapID, mapLevel = strsplit(":", itemLink)
     mapID = tonumber(mapID)
     mapLevel = tonumber(mapLevel)
 


### PR DESCRIPTION
Change in split parameters to fix #960 

Closed #961 from the suggestion there.

The value looks like this with the map ID being out one more value.

`|cn|Q4:Hkeystone:180653:382:2:0:0:0:0:h[Keystone: Theater of Pain (2))]|h|r`

This code could possibly be improved to be more resilient to future changes if the item link changes.