### PR TITLE
Bug Fixes & Quest & Progress

### DIFF
--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -3822,11 +3822,9 @@ function SI:ShowTooltip(anchorframe)
   if SI.db.Tooltip.MythicKey or showall then
     local show = false
     for toon, t in cpairs(SI.db.Toons, true) do
-      if t.MythicKey then
-        if t.MythicKey.link then
-          show = true
-          addColumns(columns, toon, tooltip)
-        end
+      if t.MythicKey and t.MythicKey.link and t.MythicKey.mapID then
+        show = true
+        addColumns(columns, toon, tooltip)
       end
     end
     if show then
@@ -3839,7 +3837,7 @@ function SI:ShowTooltip(anchorframe)
       tooltip:SetCellScript(show, 1, "OnMouseDown", ReportKeys, "MythicKey")
     end
     for toon, t in cpairs(SI.db.Toons, true) do
-      if t.MythicKey and t.MythicKey.link then
+      if t.MythicKey and t.MythicKey.link and t.MythicKey.mapID then
         local col = columns[toon .. 1]
         local mapName = C_ChallengeMode.GetMapUIInfo(t.MythicKey.mapID)
         if mapName then

--- a/SavedInstances/Modules/Progress.lua
+++ b/SavedInstances/Modules/Progress.lua
@@ -203,6 +203,16 @@ local presets = {
     persists = false,
     fullObjective = false,
   },
+  -- Delver's Bounty
+  ["delvers-bounty"] = {
+    type = "single",
+    index = 3.1,
+    name = L["Delver's Bounty"],
+    questID = 86371,
+    reset = "weekly",
+    persists = false,
+    fullObjective = false,
+  },
   -- The World Awaits
   ["the-world-awaits"] = {
     type = "single",
@@ -849,17 +859,6 @@ local presets = {
       [91177] = L["Third Cache"],
       [91178] = L["Fourth Cache"],
     },
-  },
-  -- Delver's Bounty
-  ["tww-delvers-bounty"] = {
-    type = "single",
-    expansion = 10,
-    index = 1.1,
-    name = L["Delver's Bounty"],
-    questID = 86371,
-    reset = "weekly",
-    persists = false,
-    fullObjective = false,
   },
   -- Lesser Keyflame
   ["tww-lesser-keyflame"] = {
@@ -1607,6 +1606,17 @@ local presets = {
     threshold = 4,
     progress = true,
     onlyOnOrCompleted = true,
+  },
+  -- A Nightmarish Task
+  ["mn-a-nightmarish-task"] = {
+    type = "single",
+    expansion = 11,
+    index = 7.1,
+    name = L["A Nightmarish Task"],
+    questID = 94446,
+    reset = "weekly",
+    persists = false,
+    fullObjective = false,
   },
   -- Abundant Offerings
   ["mn-abundant-offerings"] = {

--- a/SavedInstances/Modules/Quest.lua
+++ b/SavedInstances/Modules/Quest.lua
@@ -701,8 +701,9 @@ local QuestExceptions = {
   [93425] = "Weekly", -- Sparks of War: Harandar
   [93426] = "Weekly", -- Sparks of War: Voidstorm
   -- Other
-  [91966] = "Daily", -- Saltheril's Soiree
+  [89268] = "AccountWeekly", -- Lost Legends
   [90962] = "Daily", -- Stormarion Assault
+  [91966] = "Daily", -- Saltheril's Soiree
 
   -- General
   -- Darkmoon Faire


### PR DESCRIPTION
* Fixes lua error on blizzard's dummy keystone (wtf)
* Move Delver's Bounty
* Track A Nightmarish Task
* Mark Lost Legends as AccountWeekly

Might need a tag to stop the error (and the reports) after users complete Tier 11 Delve which rewards a dummy keystone.